### PR TITLE
display remote form ajax errors (touch #272)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,28 @@
 //= require twitter/bootstrap
 
 $(function(){
+
+  //////
+  // Rails support
+  //
+
+  // Display when an remote form failed
+  $(document).on('ajax:error', 'form[data-remote-error-message]', function(){
+    var message = $(this).data('remote-error-message'),
+        $target = $('.form-errors', this);
+
+    if($target.size()){
+      // create a div to show the message in
+      $('<div class="alert alert-box alert-alert"><h3></h3></div>')
+      .find('h3').text(message)
+      .end().appendTo($target);
+    } else {
+      alert(message);
+    }
+
+  });
+
+
 	// Skrollr data settings
 	var bleed = $('body.odi-bleed').attr({
 		'data-0':'background-position:0 -450px',

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -1,6 +1,6 @@
 - remote ||= false
-= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :remote => remote, :format => :json, :html => { :id => "register_user" }) do |f|
-  .registration_form_errors
+= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :remote => remote, :format => :json, :html => { :id => "register_user", 'data-remote-error-message' => t('errors.server_error') }) do |f|
+  .form-errors.registration_form_errors
     - if resource.errors.any?
       = render 'devise/sessions/form_errors'
 

--- a/app/views/devise/sessions/_form.html.haml
+++ b/app/views/devise/sessions/_form.html.haml
@@ -2,9 +2,9 @@
 - remote ||= false
 - form_id ||= 'sign_in_user_form'
 
-= form_for(resource, :as => resource_name, :url => session_path(resource_name), :remote => remote, :format => :json, :html => { :id => form_id, :class => 'sign_in_user '}) do |f|
+= form_for(resource, :as => resource_name, :url => session_path(resource_name), :remote => remote, :format => :json, :html => { :id => form_id, :class => 'sign_in_user', 'data-remote-error-message' => t('errors.server_error')}) do |f|
   = hidden_field_tag :form_id, form_id
-  .sign_in_user_form_errors
+  .form-errors.sign_in_user_form_errors
     - if errors
       = render 'devise/sessions/form_errors', locals: {errors: errors}
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,3 +153,4 @@ en:
 
   errors:
     errors_occurred: Errors occurred
+    server_error: A server error occurred


### PR DESCRIPTION
Display errors on the login/register page when the ajax request has failed.

![image](https://f.cloud.github.com/assets/51385/613813/952d409c-ce0d-11e2-8291-0d4d848a70c0.png)
