### PR TITLE
Feature fix mailer

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ OpenDataCertificate::Application.configure do
   if ENV["MANDRILL_USERNAME"]
 
     # **IMPORTANT** Define the default url (for devise)
-    config.action_mailer.default_url_options = { :host => 'odc-stage.herokuapp.com' }
+    config.action_mailer.default_url_options = { :host => 'certificate.theodi.org' }
 
     config.action_mailer.smtp_settings = {
       :address   => "smtp.mandrillapp.com",


### PR DESCRIPTION
The `ENV` variable that gets loaded in is actually `MANDRILL_PASSWORD`. This should now fix the problems with the mailers. Also changed the default URL to the production URL for good measure :smile: 
