### PR TITLE
Fix wrong level displayed via Javascript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -218,9 +218,11 @@ $(function(){
   }
 
   // Open sections that contain incomplete mandatory questions
-  $('.survey-section:has(.mandatory:not(.has-response):not(.q_hidden))')
-    .find('ul')
-    .collapse('show');
+  if ($('#surveyor').hasClass('highlight-mandatory')) {
+    $('.survey-section:has(.mandatory:not(.has-response):not(.q_hidden))')
+      .find('ul')
+      .collapse('show');
+  }
 
 
   // Questionnaire status panel


### PR DESCRIPTION
Made sure the status panel is giving the right status with checkbox questions. Also fixed a small issue with the sections opening up when the mandatory questions weren't being highlighted.
