### PR TITLE
Use memcached

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -8,7 +8,11 @@ OpenDataCertificate::Application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 #  config.cache_store = :memory_store # TODO: Default is memory store, but production will probably need to change to something else... but that decision is not yet made
-  config.cache_store = :mem_cache_store, ENV["MEMCACHED_HOSTS"]
+  config.cache_store = if ENV["MEMCACHED_HOSTS"]
+                         :mem_cache_store, ENV["MEMCACHED_HOSTS"]
+                       else
+                         :memory_store
+                       end
 
 
   # Disable Rails's static asset server (Apache or nginx will already do this)


### PR DESCRIPTION
ENV["MEMCACHED_HOSTS"] should now exist via DotEnv, I'm not sure this is the correct way to access it though. Can somebody more Rails-y take a look please?

There is now a memcached node in production.
