### PR TITLE
small fixes to T&Cs

### DIFF
--- a/app/views/pages/terms.html.haml
+++ b/app/views/pages/terms.html.haml
@@ -32,10 +32,10 @@
     %h3 Open Data Certificate specific warranties
 
     %ul
-      %li Information given on a data certificate is the responsibility of its creator and we do not verify or guarantee the accuracy of it.
-      %li We reserve the right to revoke a data certificate at any time.
-      %li The data certificate badge/logo is licensed under ???
-      %li Incomplete data certificate questionnaires are deleted from our server if the creator does not register for an account.
+      %li Information given on a open data certificate is the responsibility of its creator and we do not verify or guarantee the accuracy of it.
+      %li We reserve the right to revoke a open data certificate at any time.
+      %li The open data certificate badge is a trademark; it may only be embedded on other sites using the code provided on this site.
+      %li Incomplete open data certificate questionnaires are deleted from our server if the creator does not register for an account.
 
     %h4 To the extent permitted by law, we expressly exclude:
 


### PR DESCRIPTION
fixed T&Cs to use 'open data certificate' phrase and indicate trademark of badge
