### PR TITLE
added delayed job to the Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 thin:  RAILS_ENV=production bundle exec thin start
-
+delayed_job:  RAILS_ENV=production bundle exec rake jobs:work


### PR DESCRIPTION
This adds a `delayed_job` task for foreman.

This doesn't work with my local foreman, though it's in the same format as `thin` (which also doesn't work for me).

``` bash
foreman start thin
11:21:08 thin.1   | started with pid 38075
11:21:08 thin.1   | /Users/ben/.rvm/gems/ruby-1.9.3-p392@odc/gems/foreman-0.63.0/bin/foreman-runner: line 41: exec: RAILS_ENV=production: not found
11:21:08 thin.1   | exited with code 127
```

So I think that might be okay.
