### PR TITLE
send rake error to airbrake

### DIFF
--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -6,7 +6,7 @@ namespace :cache do
     if Rails.cache.is_a? ActiveSupport::Cache::MemoryStore
       message = 'Unable to clear cache, using :memory_store so different process from rake (you should try restarting the app server)'
       if defined? Airbrake
-        Airbrake.notify message
+        Airbrake.notify :error_message => message
       else
         raise message
       end


### PR DESCRIPTION
allows the cache:clear task not to interrupt the deployment (but still send the error to airbrake)
