### PR TITLE
Handle 404s gracefully

### DIFF
--- a/app/controllers/validators_controller.rb
+++ b/app/controllers/validators_controller.rb
@@ -12,8 +12,8 @@ class ValidatorsController < ApplicationController
   end
    
   def autofill
-    dataset = DataKitten::Dataset.new(access_url: params[:url])
-    if dataset.supported?
+    dataset = DataKitten::Dataset.new(access_url: params[:url]) rescue nil
+    if dataset != nil && dataset.supported?
       distributions = []
       
       dataset.distributions.each do |distribution|


### PR DESCRIPTION
We were getting 500 errors when checking URLs against Data Kitten that 404'd, think the easiest thing to do is just return a blank response, the same as if the dataset isn't supported. 
