### PR TITLE
Select checkboxes, radio buttons and selects by index

### DIFF
--- a/app/assets/javascripts/surveyor_all.js
+++ b/app/assets/javascripts/surveyor_all.js
@@ -391,7 +391,7 @@ jQuery(document).ready(function(){
 
           // Keywords
           if (json.keywords.length > 0) {
-            affectedFields.push(checkMe("documentationMetadata", 13))
+            affectedFields.push(checkMe("documentationMetadata", 12))
           }
 
           // Distributions


### PR DESCRIPTION
I noticed that the actual values of select boxes, checkboxes and radio button options can change from time to time (something, I assume to do with how Surveyor works behind the scenes), so rather than select these by value, I'm now selecting them by index, which will not change. Seems to work a lot more reliably now!
