### PR TITLE
don't load in @dependents for other sections (we're showing everything)

### DIFF
--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -181,7 +181,7 @@ class SurveyorController < ApplicationController
     if @response_set
       @survey = @response_set.survey
       @sections = @survey.sections.with_includes
-      set_dependents
+      @dependents = []
     else
       flash[:notice] = t('surveyor.unable_to_find_your_responses')
       redirect_to surveyor_index


### PR DESCRIPTION
We don't need to load in `@dependents` because this is to show dependent questions from hidden sections - and we are displaying them all anyway.

This can now cause an error since #418 - where we don't assign a particular `@survey`

resolves #419
