### PR TITLE
changed ids for licences

### DIFF
--- a/prototype/defaults/certificate.EU.xml
+++ b/prototype/defaults/certificate.EU.xml
@@ -149,9 +149,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -219,7 +219,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/defaults/certificate.xml
+++ b/prototype/defaults/certificate.xml
@@ -150,7 +150,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AD.xml
+++ b/prototype/jurisdictions/certificate.AD.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AE.xml
+++ b/prototype/jurisdictions/certificate.AE.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AF.xml
+++ b/prototype/jurisdictions/certificate.AF.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AG.xml
+++ b/prototype/jurisdictions/certificate.AG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AI.xml
+++ b/prototype/jurisdictions/certificate.AI.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AL.xml
+++ b/prototype/jurisdictions/certificate.AL.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AM.xml
+++ b/prototype/jurisdictions/certificate.AM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AO.xml
+++ b/prototype/jurisdictions/certificate.AO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AQ.xml
+++ b/prototype/jurisdictions/certificate.AQ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AR.xml
+++ b/prototype/jurisdictions/certificate.AR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AS.xml
+++ b/prototype/jurisdictions/certificate.AS.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AT.xml
+++ b/prototype/jurisdictions/certificate.AT.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AU.xml
+++ b/prototype/jurisdictions/certificate.AU.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AW.xml
+++ b/prototype/jurisdictions/certificate.AW.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AX.xml
+++ b/prototype/jurisdictions/certificate.AX.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.AZ.xml
+++ b/prototype/jurisdictions/certificate.AZ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BA.xml
+++ b/prototype/jurisdictions/certificate.BA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BB.xml
+++ b/prototype/jurisdictions/certificate.BB.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BD.xml
+++ b/prototype/jurisdictions/certificate.BD.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BE.xml
+++ b/prototype/jurisdictions/certificate.BE.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BF.xml
+++ b/prototype/jurisdictions/certificate.BF.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BG.xml
+++ b/prototype/jurisdictions/certificate.BG.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BH.xml
+++ b/prototype/jurisdictions/certificate.BH.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BI.xml
+++ b/prototype/jurisdictions/certificate.BI.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BJ.xml
+++ b/prototype/jurisdictions/certificate.BJ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BL.xml
+++ b/prototype/jurisdictions/certificate.BL.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BM.xml
+++ b/prototype/jurisdictions/certificate.BM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BN.xml
+++ b/prototype/jurisdictions/certificate.BN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BO.xml
+++ b/prototype/jurisdictions/certificate.BO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BQ.xml
+++ b/prototype/jurisdictions/certificate.BQ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BR.xml
+++ b/prototype/jurisdictions/certificate.BR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BS.xml
+++ b/prototype/jurisdictions/certificate.BS.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BT.xml
+++ b/prototype/jurisdictions/certificate.BT.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BV.xml
+++ b/prototype/jurisdictions/certificate.BV.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BW.xml
+++ b/prototype/jurisdictions/certificate.BW.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BY.xml
+++ b/prototype/jurisdictions/certificate.BY.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.BZ.xml
+++ b/prototype/jurisdictions/certificate.BZ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CA.xml
+++ b/prototype/jurisdictions/certificate.CA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CC.xml
+++ b/prototype/jurisdictions/certificate.CC.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CD.xml
+++ b/prototype/jurisdictions/certificate.CD.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CF.xml
+++ b/prototype/jurisdictions/certificate.CF.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CG.xml
+++ b/prototype/jurisdictions/certificate.CG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CH.xml
+++ b/prototype/jurisdictions/certificate.CH.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CI.xml
+++ b/prototype/jurisdictions/certificate.CI.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CK.xml
+++ b/prototype/jurisdictions/certificate.CK.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CL.xml
+++ b/prototype/jurisdictions/certificate.CL.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CM.xml
+++ b/prototype/jurisdictions/certificate.CM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CN.xml
+++ b/prototype/jurisdictions/certificate.CN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CO.xml
+++ b/prototype/jurisdictions/certificate.CO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CR.xml
+++ b/prototype/jurisdictions/certificate.CR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CU.xml
+++ b/prototype/jurisdictions/certificate.CU.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CV.xml
+++ b/prototype/jurisdictions/certificate.CV.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CW.xml
+++ b/prototype/jurisdictions/certificate.CW.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CX.xml
+++ b/prototype/jurisdictions/certificate.CX.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CY.xml
+++ b/prototype/jurisdictions/certificate.CY.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.CZ.xml
+++ b/prototype/jurisdictions/certificate.CZ.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.DE.xml
+++ b/prototype/jurisdictions/certificate.DE.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.DJ.xml
+++ b/prototype/jurisdictions/certificate.DJ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.DK.xml
+++ b/prototype/jurisdictions/certificate.DK.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.DM.xml
+++ b/prototype/jurisdictions/certificate.DM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.DO.xml
+++ b/prototype/jurisdictions/certificate.DO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.DZ.xml
+++ b/prototype/jurisdictions/certificate.DZ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.EC.xml
+++ b/prototype/jurisdictions/certificate.EC.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.EE.xml
+++ b/prototype/jurisdictions/certificate.EE.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.EG.xml
+++ b/prototype/jurisdictions/certificate.EG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.EH.xml
+++ b/prototype/jurisdictions/certificate.EH.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.ER.xml
+++ b/prototype/jurisdictions/certificate.ER.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.ES.xml
+++ b/prototype/jurisdictions/certificate.ES.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.ET.xml
+++ b/prototype/jurisdictions/certificate.ET.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.FI.xml
+++ b/prototype/jurisdictions/certificate.FI.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.FJ.xml
+++ b/prototype/jurisdictions/certificate.FJ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.FK.xml
+++ b/prototype/jurisdictions/certificate.FK.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.FM.xml
+++ b/prototype/jurisdictions/certificate.FM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.FO.xml
+++ b/prototype/jurisdictions/certificate.FO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.FR.xml
+++ b/prototype/jurisdictions/certificate.FR.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GA.xml
+++ b/prototype/jurisdictions/certificate.GA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GB.xml
+++ b/prototype/jurisdictions/certificate.GB.xml
@@ -149,10 +149,10 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
-					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
-					<option value="ogl">UK Open Government Licence</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
+					<option value="uk-ogl">UK Open Government Licence</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -220,8 +220,8 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
-					<option value="ogl">UK Open Government Licence</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
+					<option value="uk-ogl">UK Open Government Licence</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GD.xml
+++ b/prototype/jurisdictions/certificate.GD.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GE.xml
+++ b/prototype/jurisdictions/certificate.GE.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GF.xml
+++ b/prototype/jurisdictions/certificate.GF.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GG.xml
+++ b/prototype/jurisdictions/certificate.GG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GH.xml
+++ b/prototype/jurisdictions/certificate.GH.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GI.xml
+++ b/prototype/jurisdictions/certificate.GI.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GL.xml
+++ b/prototype/jurisdictions/certificate.GL.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GM.xml
+++ b/prototype/jurisdictions/certificate.GM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GN.xml
+++ b/prototype/jurisdictions/certificate.GN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GP.xml
+++ b/prototype/jurisdictions/certificate.GP.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GQ.xml
+++ b/prototype/jurisdictions/certificate.GQ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GR.xml
+++ b/prototype/jurisdictions/certificate.GR.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GS.xml
+++ b/prototype/jurisdictions/certificate.GS.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GT.xml
+++ b/prototype/jurisdictions/certificate.GT.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GU.xml
+++ b/prototype/jurisdictions/certificate.GU.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GW.xml
+++ b/prototype/jurisdictions/certificate.GW.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.GY.xml
+++ b/prototype/jurisdictions/certificate.GY.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.HK.xml
+++ b/prototype/jurisdictions/certificate.HK.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.HM.xml
+++ b/prototype/jurisdictions/certificate.HM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.HN.xml
+++ b/prototype/jurisdictions/certificate.HN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.HR.xml
+++ b/prototype/jurisdictions/certificate.HR.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.HT.xml
+++ b/prototype/jurisdictions/certificate.HT.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.HU.xml
+++ b/prototype/jurisdictions/certificate.HU.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.ID.xml
+++ b/prototype/jurisdictions/certificate.ID.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.IE.xml
+++ b/prototype/jurisdictions/certificate.IE.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.IL.xml
+++ b/prototype/jurisdictions/certificate.IL.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.IM.xml
+++ b/prototype/jurisdictions/certificate.IM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.IN.xml
+++ b/prototype/jurisdictions/certificate.IN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.IO.xml
+++ b/prototype/jurisdictions/certificate.IO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.IQ.xml
+++ b/prototype/jurisdictions/certificate.IQ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.IR.xml
+++ b/prototype/jurisdictions/certificate.IR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.IS.xml
+++ b/prototype/jurisdictions/certificate.IS.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.IT.xml
+++ b/prototype/jurisdictions/certificate.IT.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.JE.xml
+++ b/prototype/jurisdictions/certificate.JE.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.JM.xml
+++ b/prototype/jurisdictions/certificate.JM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.JO.xml
+++ b/prototype/jurisdictions/certificate.JO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.JP.xml
+++ b/prototype/jurisdictions/certificate.JP.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KE.xml
+++ b/prototype/jurisdictions/certificate.KE.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KG.xml
+++ b/prototype/jurisdictions/certificate.KG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KH.xml
+++ b/prototype/jurisdictions/certificate.KH.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KI.xml
+++ b/prototype/jurisdictions/certificate.KI.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KM.xml
+++ b/prototype/jurisdictions/certificate.KM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KN.xml
+++ b/prototype/jurisdictions/certificate.KN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KP.xml
+++ b/prototype/jurisdictions/certificate.KP.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KR.xml
+++ b/prototype/jurisdictions/certificate.KR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KW.xml
+++ b/prototype/jurisdictions/certificate.KW.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KY.xml
+++ b/prototype/jurisdictions/certificate.KY.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.KZ.xml
+++ b/prototype/jurisdictions/certificate.KZ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LA.xml
+++ b/prototype/jurisdictions/certificate.LA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LB.xml
+++ b/prototype/jurisdictions/certificate.LB.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LC.xml
+++ b/prototype/jurisdictions/certificate.LC.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LI.xml
+++ b/prototype/jurisdictions/certificate.LI.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LK.xml
+++ b/prototype/jurisdictions/certificate.LK.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LR.xml
+++ b/prototype/jurisdictions/certificate.LR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LS.xml
+++ b/prototype/jurisdictions/certificate.LS.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LT.xml
+++ b/prototype/jurisdictions/certificate.LT.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LU.xml
+++ b/prototype/jurisdictions/certificate.LU.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LV.xml
+++ b/prototype/jurisdictions/certificate.LV.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.LY.xml
+++ b/prototype/jurisdictions/certificate.LY.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MA.xml
+++ b/prototype/jurisdictions/certificate.MA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MC.xml
+++ b/prototype/jurisdictions/certificate.MC.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MD.xml
+++ b/prototype/jurisdictions/certificate.MD.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.ME.xml
+++ b/prototype/jurisdictions/certificate.ME.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MF.xml
+++ b/prototype/jurisdictions/certificate.MF.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MG.xml
+++ b/prototype/jurisdictions/certificate.MG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MH.xml
+++ b/prototype/jurisdictions/certificate.MH.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MK.xml
+++ b/prototype/jurisdictions/certificate.MK.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.ML.xml
+++ b/prototype/jurisdictions/certificate.ML.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MM.xml
+++ b/prototype/jurisdictions/certificate.MM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MN.xml
+++ b/prototype/jurisdictions/certificate.MN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MO.xml
+++ b/prototype/jurisdictions/certificate.MO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MP.xml
+++ b/prototype/jurisdictions/certificate.MP.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MQ.xml
+++ b/prototype/jurisdictions/certificate.MQ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MR.xml
+++ b/prototype/jurisdictions/certificate.MR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MS.xml
+++ b/prototype/jurisdictions/certificate.MS.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MT.xml
+++ b/prototype/jurisdictions/certificate.MT.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MU.xml
+++ b/prototype/jurisdictions/certificate.MU.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MV.xml
+++ b/prototype/jurisdictions/certificate.MV.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MW.xml
+++ b/prototype/jurisdictions/certificate.MW.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MX.xml
+++ b/prototype/jurisdictions/certificate.MX.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MY.xml
+++ b/prototype/jurisdictions/certificate.MY.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.MZ.xml
+++ b/prototype/jurisdictions/certificate.MZ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NA.xml
+++ b/prototype/jurisdictions/certificate.NA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NC.xml
+++ b/prototype/jurisdictions/certificate.NC.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NE.xml
+++ b/prototype/jurisdictions/certificate.NE.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NF.xml
+++ b/prototype/jurisdictions/certificate.NF.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NG.xml
+++ b/prototype/jurisdictions/certificate.NG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NI.xml
+++ b/prototype/jurisdictions/certificate.NI.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NL.xml
+++ b/prototype/jurisdictions/certificate.NL.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NO.xml
+++ b/prototype/jurisdictions/certificate.NO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NP.xml
+++ b/prototype/jurisdictions/certificate.NP.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NR.xml
+++ b/prototype/jurisdictions/certificate.NR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NU.xml
+++ b/prototype/jurisdictions/certificate.NU.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.NZ.xml
+++ b/prototype/jurisdictions/certificate.NZ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.OM.xml
+++ b/prototype/jurisdictions/certificate.OM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PA.xml
+++ b/prototype/jurisdictions/certificate.PA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PE.xml
+++ b/prototype/jurisdictions/certificate.PE.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PF.xml
+++ b/prototype/jurisdictions/certificate.PF.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PG.xml
+++ b/prototype/jurisdictions/certificate.PG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PH.xml
+++ b/prototype/jurisdictions/certificate.PH.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PK.xml
+++ b/prototype/jurisdictions/certificate.PK.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PL.xml
+++ b/prototype/jurisdictions/certificate.PL.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PM.xml
+++ b/prototype/jurisdictions/certificate.PM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PN.xml
+++ b/prototype/jurisdictions/certificate.PN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PR.xml
+++ b/prototype/jurisdictions/certificate.PR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PS.xml
+++ b/prototype/jurisdictions/certificate.PS.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PT.xml
+++ b/prototype/jurisdictions/certificate.PT.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PW.xml
+++ b/prototype/jurisdictions/certificate.PW.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.PY.xml
+++ b/prototype/jurisdictions/certificate.PY.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.QA.xml
+++ b/prototype/jurisdictions/certificate.QA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.RE.xml
+++ b/prototype/jurisdictions/certificate.RE.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.RO.xml
+++ b/prototype/jurisdictions/certificate.RO.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.RS.xml
+++ b/prototype/jurisdictions/certificate.RS.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.RU.xml
+++ b/prototype/jurisdictions/certificate.RU.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.RW.xml
+++ b/prototype/jurisdictions/certificate.RW.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SA.xml
+++ b/prototype/jurisdictions/certificate.SA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SB.xml
+++ b/prototype/jurisdictions/certificate.SB.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SC.xml
+++ b/prototype/jurisdictions/certificate.SC.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SD.xml
+++ b/prototype/jurisdictions/certificate.SD.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SE.xml
+++ b/prototype/jurisdictions/certificate.SE.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SG.xml
+++ b/prototype/jurisdictions/certificate.SG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SH.xml
+++ b/prototype/jurisdictions/certificate.SH.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SI.xml
+++ b/prototype/jurisdictions/certificate.SI.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SJ.xml
+++ b/prototype/jurisdictions/certificate.SJ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SK.xml
+++ b/prototype/jurisdictions/certificate.SK.xml
@@ -147,9 +147,9 @@
 				<select required="required">
 					<option/>
 					<option value="odc-by">Open Data Commons Attribution License</option>
-					<option value="odc-by-sa">Open Data Commons Open Database License (ODbL)</option>
+					<option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
 					<option value="pddl">Open Data Commons Public Domain Dedication and Licence (PDDL)</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>
@@ -217,7 +217,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SL.xml
+++ b/prototype/jurisdictions/certificate.SL.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SM.xml
+++ b/prototype/jurisdictions/certificate.SM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SN.xml
+++ b/prototype/jurisdictions/certificate.SN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SO.xml
+++ b/prototype/jurisdictions/certificate.SO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SR.xml
+++ b/prototype/jurisdictions/certificate.SR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SS.xml
+++ b/prototype/jurisdictions/certificate.SS.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.ST.xml
+++ b/prototype/jurisdictions/certificate.ST.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SV.xml
+++ b/prototype/jurisdictions/certificate.SV.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SX.xml
+++ b/prototype/jurisdictions/certificate.SX.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SY.xml
+++ b/prototype/jurisdictions/certificate.SY.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.SZ.xml
+++ b/prototype/jurisdictions/certificate.SZ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TC.xml
+++ b/prototype/jurisdictions/certificate.TC.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TD.xml
+++ b/prototype/jurisdictions/certificate.TD.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TF.xml
+++ b/prototype/jurisdictions/certificate.TF.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TG.xml
+++ b/prototype/jurisdictions/certificate.TG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TH.xml
+++ b/prototype/jurisdictions/certificate.TH.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TJ.xml
+++ b/prototype/jurisdictions/certificate.TJ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TK.xml
+++ b/prototype/jurisdictions/certificate.TK.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TL.xml
+++ b/prototype/jurisdictions/certificate.TL.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TM.xml
+++ b/prototype/jurisdictions/certificate.TM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TN.xml
+++ b/prototype/jurisdictions/certificate.TN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TO.xml
+++ b/prototype/jurisdictions/certificate.TO.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TR.xml
+++ b/prototype/jurisdictions/certificate.TR.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TT.xml
+++ b/prototype/jurisdictions/certificate.TT.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TV.xml
+++ b/prototype/jurisdictions/certificate.TV.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TW.xml
+++ b/prototype/jurisdictions/certificate.TW.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.TZ.xml
+++ b/prototype/jurisdictions/certificate.TZ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.UA.xml
+++ b/prototype/jurisdictions/certificate.UA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.UG.xml
+++ b/prototype/jurisdictions/certificate.UG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.UM.xml
+++ b/prototype/jurisdictions/certificate.UM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.US.xml
+++ b/prototype/jurisdictions/certificate.US.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.UY.xml
+++ b/prototype/jurisdictions/certificate.UY.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.UZ.xml
+++ b/prototype/jurisdictions/certificate.UZ.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.VA.xml
+++ b/prototype/jurisdictions/certificate.VA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.VC.xml
+++ b/prototype/jurisdictions/certificate.VC.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.VE.xml
+++ b/prototype/jurisdictions/certificate.VE.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.VG.xml
+++ b/prototype/jurisdictions/certificate.VG.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.VI.xml
+++ b/prototype/jurisdictions/certificate.VI.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.VN.xml
+++ b/prototype/jurisdictions/certificate.VN.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.VU.xml
+++ b/prototype/jurisdictions/certificate.VU.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.WF.xml
+++ b/prototype/jurisdictions/certificate.WF.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.WS.xml
+++ b/prototype/jurisdictions/certificate.WS.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.YE.xml
+++ b/prototype/jurisdictions/certificate.YE.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.YT.xml
+++ b/prototype/jurisdictions/certificate.YT.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.ZA.xml
+++ b/prototype/jurisdictions/certificate.ZA.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.ZM.xml
+++ b/prototype/jurisdictions/certificate.ZM.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>

--- a/prototype/jurisdictions/certificate.ZW.xml
+++ b/prototype/jurisdictions/certificate.ZW.xml
@@ -148,7 +148,7 @@
 					<option/>
 					<option value="cc-by">Creative Commons Attribution</option>
 					<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-					<option value="cc0">Creative Commons CCZero</option>
+					<option value="cc-zero">Creative Commons CCZero</option>
 					<option value="na" display="">Not applicable</option>
 					<option value="other" display="">Other...</option>
 				</select>


### PR DESCRIPTION
this is to tally with those available in the http://licenses.opendefinition.org API, so that information about the licences
can be pulled back from that API
