### PR TITLE
added migration to generate curators by delayed job

### DIFF
--- a/db/migrate/20130809150653_populate_curator_for_certificates.rb
+++ b/db/migrate/20130809150653_populate_curator_for_certificates.rb
@@ -1,0 +1,10 @@
+class PopulateCuratorForCertificates < ActiveRecord::Migration
+  def up
+    Certificate.where(curator: nil).find_each(batch_size: 20) do |c| 
+      c.delay.update_from_response_set unless c.response_set.nil?
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130806160042) do
+ActiveRecord::Schema.define(:version => 20130809150653) do
 
   create_table "answers", :force => true do |t|
     t.integer  "question_id"


### PR DESCRIPTION
This is a replacement for a migration that was failing before - https://github.com/theodi/open-data-certificate/blob/master/db/migrate/20130731203215_recompute_dataset_curator_for_certificates.rb - the task will be done as delayed jobs, so shouldn't chew up resources on deploy.

Once completed - the publisher will be displayed on https://certificates.theodi.org/datasets
