### PR TITLE
set secret token from environment variable in production

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,11 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-OpenDataCertificate::Application.config.secret_token = '2da17efb8c0932028001e92cfb3b2da01cfc351f95f7628cac4e20e1bb19df2c6b9416ece51e947b784cb57edd6b65a4cef2e49a6f8e8ff9d0b7fcb736800bb4'
+
+
+if Rails.env.production?
+  raise "Session secret not set!" unless ENV['SESSION_SECRET_CERTIFICATE']
+  OpenDataCertificate::Application.config.secret_token = ENV['SESSION_SECRET_CERTIFICATE']
+else
+  OpenDataCertificate::Application.config.secret_token = '2da17efb8c0932028001e92cfb3b2da01cfc351f95f7628cac4e20e1bb19df2c6b9416ece51e947b784cb57edd6b65a4cef2e49a6f8e8ff9d0b7fcb736800bb4'
+end


### PR DESCRIPTION
The secret token is hard coded in the config, this will read it from an environment variable instead (used approach from [member-directory](https://github.com/theodi/member-directory/blob/master/config/initializers/secret_token.rb))

The `SESSION_SECRET_CERTIFICATE` env var will have to be set before this can be deployed.

`ruby -e "require 'securerandom'; puts SecureRandom.hex(32)"` gives the kind of value for it.

This will expire all current sessions on the site
