### PR TITLE
tweak the login forms to remove existing errors when submitted

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,13 +16,15 @@ $(function(){
 
     if($target.size()){
       // create a div to show the message in
-      $('<div class="alert alert-box alert-alert"><h3></h3></div>')
-      .find('h3').text(message)
-      .end().appendTo($target);
+      $('<div>',{class:'alert alert-box alert-alert'})
+      .append($('<h3>',{text:message}))
+      .appendTo($target);
     } else {
       alert(message);
     }
 
+  }).on('ajax:beforeSend.rails', 'form[data-remote-error-message]', function(){
+    $('.form-errors', this).empty();
   });
 
   // Skrollr data settings


### PR DESCRIPTION
This is a quick fix to remove the existing login error when you submit new information (it gets replaced when the response comes back from the form).

![image](https://f.cloud.github.com/assets/51385/987171/a253912c-08e6-11e3-8c12-0a434c8c996f.png)
