### PR TITLE
removing highlight_mandatory from the question partial

### DIFF
--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -1742,7 +1742,7 @@ header .jurisdiction{
       }
     }
 
-    &.error {
+    .highlight_mandatory&.mandatory.no-response{
       background: @odiCrimsonLight;
 
       input.string {

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -17,7 +17,6 @@
     - r = response_for(@response_set, q, nil, rg)
 
     - state = 'ok' unless r.new_record?
-    - state = 'error' if highlight_mandatory && q.is_mandatory && r.new_record?
     - state = 'warning' if r.error
 
     - classes = {'row' => true, 'question-row' => true, "q_#{renderer}" => true}
@@ -25,6 +24,7 @@
     - classes['choice-boxes'] = q.pick == "one" || q.pick == "any"
     - classes['mandatory'] = q.is_mandatory
     - classes['has-response'] = !r.new_record?
+    - classes['no-response'] = r.new_record?
     - classes['autocompleted'] = r.autocompleted
     - classes[state] = true if state
 

--- a/app/views/partials/_question_group.html.haml
+++ b/app/views/partials/_question_group.html.haml
@@ -39,8 +39,8 @@
           - (@response_set.count_group_responses(qs) + 1).times do |rg|
             %li
               - qs.each do |q|
-                = render q.custom_renderer || "/partials/question", :g => g, :rg => rg, :q => q, :f => f, :highlight_mandatory => highlight_mandatory
+                = render q.custom_renderer || "/partials/question", :g => g, :rg => rg, :q => q, :f => f
           = submit_tag("Add #{g.text_for(@render_context, I18n.locale)}", :name => "section[#{qs.first.survey_section_id}][g_#{g.id}]", :class => "btn btn-primary add_row")
         - else # :inline
           - qs.each do |q|
-            = render q.custom_renderer || "/partials/question", :g => g, :q => q, :f => f, :highlight_mandatory => highlight_mandatory
+            = render q.custom_renderer || "/partials/question", :g => g, :q => q, :f => f

--- a/app/views/partials/_section.html.haml
+++ b/app/views/partials/_section.html.haml
@@ -12,7 +12,7 @@
         - qs << q # gather up the group questions
         - if (i+1 >= questions.size) or (q.question_group_id != questions[i+1].question_group_id)
           - # this is the last question of the section, or the group
-          = render q.question_group.custom_renderer || "/partials/question_group", :g => q.question_group, :qs => qs, :f => f, :highlight_mandatory => highlight_mandatory
+          = render q.question_group.custom_renderer || "/partials/question_group", :g => q.question_group, :qs => qs, :f => f
           - qs = []
       - else # gather up the group questions
-        = render q.custom_renderer || "/partials/question", :q => q, :f => f, :highlight_mandatory => highlight_mandatory
+        = render q.custom_renderer || "/partials/question", :q => q, :f => f

--- a/app/views/surveyor/edit.html.haml
+++ b/app/views/surveyor/edit.html.haml
@@ -32,7 +32,7 @@
   = render :partial => 'status_panel'
   = render :partial => 'shared/flashes'
 
-  #surveyor{'data-url-incorrect' => t('surveyor.please_check_that_the_url_exists'), 'data-autocompleted' => t('surveyor.autocompleted_data'), 'data-autocompleted-url-incorrect' => t('surveyor.autocompleted_url_incorrect')}
+  #surveyor{'data-url-incorrect' => t('surveyor.please_check_that_the_url_exists'), 'data-autocompleted' => t('surveyor.autocompleted_data'), 'data-autocompleted-url-incorrect' => t('surveyor.autocompleted_url_incorrect'), class: (params[:highlight_mandatory] ? 'highlight_mandatory' : '')}
     = hidden_field_tag :surveyor_javascript_enabled, false
 
     .container
@@ -45,7 +45,7 @@
     -# other new users
     - cache_key = @response_set.responses.empty? ? "blank_survey_#{@response_set.survey_id}" : @response_set
     = cache(cache_key) do
-      =render :partial => '/partials/section', :collection => @sections, :locals => {:f => f, :highlight_mandatory => params[:highlight_mandatory]}
+      =render :partial => '/partials/section', :collection => @sections, :locals => {:f => f}
 
 :javascript
   $(document).ready(function() {


### PR DESCRIPTION
The question view was being driven by `params[:highlight_mandatory]` (given as a local variable to the partial), which was:
- messing with caching
- causing an error when the `show` action wasn't providing the variable

I've switched it back to swapping a class on the outer `div#surveyor`
