### PR TITLE
Globe tweaks

### DIFF
--- a/app/assets/homepage_map/map.js
+++ b/app/assets/homepage_map/map.js
@@ -4,6 +4,9 @@
 
 $(function(){
 
+  // hide the panel when d3 is unsupported
+  if(typeof(d3) === 'undefined') return $('#international-reach').hide();
+
   var colours = {
     alpha: "#666",
     beta: "#000",


### PR DESCRIPTION
This fails properly when d3 isn't present (ie7/8) - hiding the globe element on the page - touch #465 

It also helps to keep the homepage parallax a bit smoother by only auto-advancing the jurisdiction when the element is in view.
