### PR TITLE
added a basic count of the certificates to the status page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,14 @@ class ApplicationController < ActionController::Base
 
   def status
     @job_count = Delayed::Job.count
+
+    @counts = {
+      'Published Certificates' =>            Certificate.where(published: true).count,
+      'Published Certificates This Month' => Certificate.where(published: true).where('"created_at" > ?', [Time.now - 1.month]).count,
+      'Published Datasets' =>                ResponseSet.published.select("DISTINCT(dataset_id)").count,
+      'Published Datasets This Month' =>     ResponseSet.published.select("DISTINCT(dataset_id)").where('"created_at" > ?', [Time.now - 1.month]).count
+    }
+
     respond_to do |format|
       format.html { render '/home/status' }
     end

--- a/app/views/home/status.html.haml
+++ b/app/views/home/status.html.haml
@@ -7,3 +7,14 @@
 %p
   %strong= pluralize @job_count, 'jobs'
   queued
+
+%hr.heavy
+
+%h1
+  Certificate Counts
+
+%ul
+  -@counts.each do |k,count|
+    %li
+      %strong= k
+      = count


### PR DESCRIPTION
This adds some counts to the [/status](https://certificates.theodi.org/status) page
- Published Certificates
- Published Certificates This Month
- Published Datasets
- Published Datasets This Month
