### PR TITLE
Certificate counts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,20 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def status_response_sets
+    @response_sets = ResponseSet.all.map do |m|
+      {
+        id: m.id,
+        created_at: m.created_at.to_i,
+        state: m.aasm_state
+      }
+    end
+
+    respond_to do |format|
+      format.json { render json: @response_sets.to_json  }
+    end
+  end
+
   # A user pings this url if they have js enabled, so we can tell surveyor
   # not to find unnecessary requirements.
   def has_js

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ OpenDataCertificate::Application.routes.draw do
 
   # (public) stats about the application
   get 'status' => 'application#status'
+  get 'status/response_sets' => 'application#status_response_sets'
 
   root :to => 'application#home'
 


### PR DESCRIPTION
This gives counts for the unpublished certificates & datasets on the [status](https://certificates.theodi.org/status) page.  Also provides `/status/response_sets.json` which lists all response_sets with their state and creation date.
