### PR TITLE
catch any errors in computing fields from datakitten

### DIFF
--- a/app/models/kitten_data.rb
+++ b/app/models/kitten_data.rb
@@ -60,6 +60,8 @@ class KittenData < ActiveRecord::Base
 
     return @fields if !data
 
+    begin
+
     @fields["dataTitle"] = data[:title]
 
     if data[:publishers].any?
@@ -132,6 +134,12 @@ class KittenData < ActiveRecord::Base
     metadata.push("temporal") unless data[:temporal_coverage].start.nil? && data[:temporal_coverage].end.nil?
 
     @fields["documentationMetadata"] = metadata
+
+    rescue => ex
+      if defined? notify_airbrake
+        notify_airbrake ex
+      end
+    end
 
     @fields
   end


### PR DESCRIPTION
This is a temporary fix for some of the errors that we're getting on production at the moment.

Seems to be some problems with bringing the data kitten output into the response_set - this change will make that fail silently for the user (but still submit to airbrake)
