### PR TITLE
Rename `curator_determined_from_responses` to `dataset_curator_determined_from_responses`

### DIFF
--- a/app/helpers/certificates_helper.rb
+++ b/app/helpers/certificates_helper.rb
@@ -65,7 +65,7 @@ module CertificatesHelper
     publisher = RDF::Node.new
     graph << [dataset, prefixes[:dct].publisher, publisher]
     graph << [publisher, RDF.type, prefixes[:foaf].Organization]
-    graph << [publisher, prefixes[:foaf].name, RDF::Literal.new(certificate.response_set.curator_determined_from_responses, :language => certificate.survey.language.to_sym)]
+    graph << [publisher, prefixes[:foaf].name, RDF::Literal.new(certificate.response_set.dataset_curator_determined_from_responses, :language => certificate.survey.language.to_sym)]
     
     rights = RDF::Node.new
     graph << [dataset, prefixes[:dct].rights, rights]

--- a/app/views/certificates/show.json.jbuilder
+++ b/app/views/certificates/show.json.jbuilder
@@ -7,7 +7,7 @@ json.certificate do |certificate|
 	certificate.uri dataset_certificate_url(@certificate.dataset, @certificate)
 	certificate.dataset do |dataset|
 	  dataset.title @certificate.response_set.title
-	  dataset.publisher @certificate.response_set.curator_determined_from_responses
+	  dataset.publisher @certificate.response_set.dataset_curator_determined_from_responses
 	  dataset.uri dataset_url(@certificate.dataset)
     dataset.dataLicense @certificate.response_set.data_licence_determined_from_responses[:url]
     dataset.contentLicense @certificate.response_set.content_licence_determined_from_responses[:url]


### PR DESCRIPTION
Fixes #563 

I think this is related to #486, but these methods didn't get renamed. There should probably be tests for the JSON, so any issues get caught in future. I'll look into that if I get chance.
