### PR TITLE
copy all responses at once

### DIFF
--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -283,8 +283,8 @@ class ResponseSet < ActiveRecord::Base
                               answer_id: answer.id.to_s }.merge(previous_response.ui_hash_values)
         end
       end
-      update_from_ui_hash(ui_hash)
     end
+    update_from_ui_hash(ui_hash)
   end
 
 


### PR DESCRIPTION
Looks like this might be the issue that was causing the `/continue` requests to be slow.

The `update_from_ui_hash` method was being called with each response being copied across to the new survey, when it could be called at the end.

Locally, this has reduced the continue time from about 2 minutes to 4 seconds to continue a test response set.
