### PR TITLE
Error page formatting

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,5 +1,8 @@
 if ENV['AIRBRAKE_CERTIFICATE_KEY']
   Airbrake.configure do |config|
     config.api_key = ENV['AIRBRAKE_CERTIFICATE_KEY']
+
+    # displayed in the 500.html error page
+    config.user_information = "Exception ID <strong>{{ error_id }}</strong>"
   end
 end

--- a/public/500.html
+++ b/public/500.html
@@ -36,6 +36,9 @@
     <div class="container main-default container" id="main" style="min-height:500px;">
       <!-- content -->
       <p class="lead">We had a problem serving this page</p>
+      <p>
+        <!-- AIRBRAKE ERROR -->
+      </p>
     </div>
     <footer id="footer">
       <div class="container">


### PR DESCRIPTION
This should display the airbrake id in the 500 error page.

![screen shot 2013-09-13 at 14 19 05](https://f.cloud.github.com/assets/51385/1138510/7ed1060e-1c77-11e3-9a76-a9fc0c918864.png)
