### PR TITLE
Permitting certificate for data when rights are unclear

### DIFF
--- a/prototype/defaults/certificate.EU.xml
+++ b/prototype/defaults/certificate.EU.xml
@@ -215,10 +215,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain" />
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -227,12 +235,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/defaults/certificate.xml
+++ b/prototype/defaults/certificate.xml
@@ -215,10 +215,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain" />
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -227,12 +235,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AD.xml
+++ b/prototype/jurisdictions/certificate.AD.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AE.xml
+++ b/prototype/jurisdictions/certificate.AE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AF.xml
+++ b/prototype/jurisdictions/certificate.AF.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AG.xml
+++ b/prototype/jurisdictions/certificate.AG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AI.xml
+++ b/prototype/jurisdictions/certificate.AI.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AL.xml
+++ b/prototype/jurisdictions/certificate.AL.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AM.xml
+++ b/prototype/jurisdictions/certificate.AM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AO.xml
+++ b/prototype/jurisdictions/certificate.AO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AQ.xml
+++ b/prototype/jurisdictions/certificate.AQ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AR.xml
+++ b/prototype/jurisdictions/certificate.AR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AS.xml
+++ b/prototype/jurisdictions/certificate.AS.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AT.xml
+++ b/prototype/jurisdictions/certificate.AT.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AU.xml
+++ b/prototype/jurisdictions/certificate.AU.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AW.xml
+++ b/prototype/jurisdictions/certificate.AW.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AX.xml
+++ b/prototype/jurisdictions/certificate.AX.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.AZ.xml
+++ b/prototype/jurisdictions/certificate.AZ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BA.xml
+++ b/prototype/jurisdictions/certificate.BA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BB.xml
+++ b/prototype/jurisdictions/certificate.BB.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BD.xml
+++ b/prototype/jurisdictions/certificate.BD.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BE.xml
+++ b/prototype/jurisdictions/certificate.BE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BF.xml
+++ b/prototype/jurisdictions/certificate.BF.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BG.xml
+++ b/prototype/jurisdictions/certificate.BG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BH.xml
+++ b/prototype/jurisdictions/certificate.BH.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BI.xml
+++ b/prototype/jurisdictions/certificate.BI.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BJ.xml
+++ b/prototype/jurisdictions/certificate.BJ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BL.xml
+++ b/prototype/jurisdictions/certificate.BL.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BM.xml
+++ b/prototype/jurisdictions/certificate.BM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BN.xml
+++ b/prototype/jurisdictions/certificate.BN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BO.xml
+++ b/prototype/jurisdictions/certificate.BO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BQ.xml
+++ b/prototype/jurisdictions/certificate.BQ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BR.xml
+++ b/prototype/jurisdictions/certificate.BR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BS.xml
+++ b/prototype/jurisdictions/certificate.BS.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BT.xml
+++ b/prototype/jurisdictions/certificate.BT.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BV.xml
+++ b/prototype/jurisdictions/certificate.BV.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BW.xml
+++ b/prototype/jurisdictions/certificate.BW.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BY.xml
+++ b/prototype/jurisdictions/certificate.BY.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.BZ.xml
+++ b/prototype/jurisdictions/certificate.BZ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CA.xml
+++ b/prototype/jurisdictions/certificate.CA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CC.xml
+++ b/prototype/jurisdictions/certificate.CC.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CD.xml
+++ b/prototype/jurisdictions/certificate.CD.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CF.xml
+++ b/prototype/jurisdictions/certificate.CF.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CG.xml
+++ b/prototype/jurisdictions/certificate.CG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CH.xml
+++ b/prototype/jurisdictions/certificate.CH.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CI.xml
+++ b/prototype/jurisdictions/certificate.CI.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CK.xml
+++ b/prototype/jurisdictions/certificate.CK.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CL.xml
+++ b/prototype/jurisdictions/certificate.CL.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CM.xml
+++ b/prototype/jurisdictions/certificate.CM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CN.xml
+++ b/prototype/jurisdictions/certificate.CN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CO.xml
+++ b/prototype/jurisdictions/certificate.CO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CR.xml
+++ b/prototype/jurisdictions/certificate.CR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CU.xml
+++ b/prototype/jurisdictions/certificate.CU.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CV.xml
+++ b/prototype/jurisdictions/certificate.CV.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CW.xml
+++ b/prototype/jurisdictions/certificate.CW.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CX.xml
+++ b/prototype/jurisdictions/certificate.CX.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CY.xml
+++ b/prototype/jurisdictions/certificate.CY.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.CZ.xml
+++ b/prototype/jurisdictions/certificate.CZ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.DE.xml
+++ b/prototype/jurisdictions/certificate.DE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.DJ.xml
+++ b/prototype/jurisdictions/certificate.DJ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.DK.xml
+++ b/prototype/jurisdictions/certificate.DK.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.DM.xml
+++ b/prototype/jurisdictions/certificate.DM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.DO.xml
+++ b/prototype/jurisdictions/certificate.DO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.DZ.xml
+++ b/prototype/jurisdictions/certificate.DZ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.EC.xml
+++ b/prototype/jurisdictions/certificate.EC.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.EE.xml
+++ b/prototype/jurisdictions/certificate.EE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.EG.xml
+++ b/prototype/jurisdictions/certificate.EG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.EH.xml
+++ b/prototype/jurisdictions/certificate.EH.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.ER.xml
+++ b/prototype/jurisdictions/certificate.ER.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.ES.xml
+++ b/prototype/jurisdictions/certificate.ES.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.ET.xml
+++ b/prototype/jurisdictions/certificate.ET.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.FI.xml
+++ b/prototype/jurisdictions/certificate.FI.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.FJ.xml
+++ b/prototype/jurisdictions/certificate.FJ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.FK.xml
+++ b/prototype/jurisdictions/certificate.FK.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.FM.xml
+++ b/prototype/jurisdictions/certificate.FM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.FO.xml
+++ b/prototype/jurisdictions/certificate.FO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.FR.xml
+++ b/prototype/jurisdictions/certificate.FR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GA.xml
+++ b/prototype/jurisdictions/certificate.GA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GB.xml
+++ b/prototype/jurisdictions/certificate.GB.xml
@@ -216,10 +216,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain" />
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -229,12 +237,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GD.xml
+++ b/prototype/jurisdictions/certificate.GD.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GE.xml
+++ b/prototype/jurisdictions/certificate.GE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GF.xml
+++ b/prototype/jurisdictions/certificate.GF.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GG.xml
+++ b/prototype/jurisdictions/certificate.GG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GH.xml
+++ b/prototype/jurisdictions/certificate.GH.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GI.xml
+++ b/prototype/jurisdictions/certificate.GI.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GL.xml
+++ b/prototype/jurisdictions/certificate.GL.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GM.xml
+++ b/prototype/jurisdictions/certificate.GM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GN.xml
+++ b/prototype/jurisdictions/certificate.GN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GP.xml
+++ b/prototype/jurisdictions/certificate.GP.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GQ.xml
+++ b/prototype/jurisdictions/certificate.GQ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GR.xml
+++ b/prototype/jurisdictions/certificate.GR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GS.xml
+++ b/prototype/jurisdictions/certificate.GS.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GT.xml
+++ b/prototype/jurisdictions/certificate.GT.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GU.xml
+++ b/prototype/jurisdictions/certificate.GU.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GW.xml
+++ b/prototype/jurisdictions/certificate.GW.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.GY.xml
+++ b/prototype/jurisdictions/certificate.GY.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.HK.xml
+++ b/prototype/jurisdictions/certificate.HK.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.HM.xml
+++ b/prototype/jurisdictions/certificate.HM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.HN.xml
+++ b/prototype/jurisdictions/certificate.HN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.HR.xml
+++ b/prototype/jurisdictions/certificate.HR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.HT.xml
+++ b/prototype/jurisdictions/certificate.HT.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.HU.xml
+++ b/prototype/jurisdictions/certificate.HU.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.ID.xml
+++ b/prototype/jurisdictions/certificate.ID.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.IE.xml
+++ b/prototype/jurisdictions/certificate.IE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.IL.xml
+++ b/prototype/jurisdictions/certificate.IL.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.IM.xml
+++ b/prototype/jurisdictions/certificate.IM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.IN.xml
+++ b/prototype/jurisdictions/certificate.IN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.IO.xml
+++ b/prototype/jurisdictions/certificate.IO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.IQ.xml
+++ b/prototype/jurisdictions/certificate.IQ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.IR.xml
+++ b/prototype/jurisdictions/certificate.IR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.IS.xml
+++ b/prototype/jurisdictions/certificate.IS.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.IT.xml
+++ b/prototype/jurisdictions/certificate.IT.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.JE.xml
+++ b/prototype/jurisdictions/certificate.JE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.JM.xml
+++ b/prototype/jurisdictions/certificate.JM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.JO.xml
+++ b/prototype/jurisdictions/certificate.JO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.JP.xml
+++ b/prototype/jurisdictions/certificate.JP.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KE.xml
+++ b/prototype/jurisdictions/certificate.KE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KG.xml
+++ b/prototype/jurisdictions/certificate.KG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KH.xml
+++ b/prototype/jurisdictions/certificate.KH.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KI.xml
+++ b/prototype/jurisdictions/certificate.KI.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KM.xml
+++ b/prototype/jurisdictions/certificate.KM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KN.xml
+++ b/prototype/jurisdictions/certificate.KN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KP.xml
+++ b/prototype/jurisdictions/certificate.KP.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KR.xml
+++ b/prototype/jurisdictions/certificate.KR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KW.xml
+++ b/prototype/jurisdictions/certificate.KW.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KY.xml
+++ b/prototype/jurisdictions/certificate.KY.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.KZ.xml
+++ b/prototype/jurisdictions/certificate.KZ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LA.xml
+++ b/prototype/jurisdictions/certificate.LA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LB.xml
+++ b/prototype/jurisdictions/certificate.LB.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LC.xml
+++ b/prototype/jurisdictions/certificate.LC.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LI.xml
+++ b/prototype/jurisdictions/certificate.LI.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LK.xml
+++ b/prototype/jurisdictions/certificate.LK.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LR.xml
+++ b/prototype/jurisdictions/certificate.LR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LS.xml
+++ b/prototype/jurisdictions/certificate.LS.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LT.xml
+++ b/prototype/jurisdictions/certificate.LT.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LU.xml
+++ b/prototype/jurisdictions/certificate.LU.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LV.xml
+++ b/prototype/jurisdictions/certificate.LV.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.LY.xml
+++ b/prototype/jurisdictions/certificate.LY.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MA.xml
+++ b/prototype/jurisdictions/certificate.MA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MC.xml
+++ b/prototype/jurisdictions/certificate.MC.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MD.xml
+++ b/prototype/jurisdictions/certificate.MD.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.ME.xml
+++ b/prototype/jurisdictions/certificate.ME.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MF.xml
+++ b/prototype/jurisdictions/certificate.MF.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MG.xml
+++ b/prototype/jurisdictions/certificate.MG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MH.xml
+++ b/prototype/jurisdictions/certificate.MH.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MK.xml
+++ b/prototype/jurisdictions/certificate.MK.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.ML.xml
+++ b/prototype/jurisdictions/certificate.ML.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MM.xml
+++ b/prototype/jurisdictions/certificate.MM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MN.xml
+++ b/prototype/jurisdictions/certificate.MN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MO.xml
+++ b/prototype/jurisdictions/certificate.MO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MP.xml
+++ b/prototype/jurisdictions/certificate.MP.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MQ.xml
+++ b/prototype/jurisdictions/certificate.MQ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MR.xml
+++ b/prototype/jurisdictions/certificate.MR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MS.xml
+++ b/prototype/jurisdictions/certificate.MS.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MT.xml
+++ b/prototype/jurisdictions/certificate.MT.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MU.xml
+++ b/prototype/jurisdictions/certificate.MU.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MV.xml
+++ b/prototype/jurisdictions/certificate.MV.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MW.xml
+++ b/prototype/jurisdictions/certificate.MW.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MX.xml
+++ b/prototype/jurisdictions/certificate.MX.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MY.xml
+++ b/prototype/jurisdictions/certificate.MY.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.MZ.xml
+++ b/prototype/jurisdictions/certificate.MZ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NA.xml
+++ b/prototype/jurisdictions/certificate.NA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NC.xml
+++ b/prototype/jurisdictions/certificate.NC.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NE.xml
+++ b/prototype/jurisdictions/certificate.NE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NF.xml
+++ b/prototype/jurisdictions/certificate.NF.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NG.xml
+++ b/prototype/jurisdictions/certificate.NG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NI.xml
+++ b/prototype/jurisdictions/certificate.NI.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NL.xml
+++ b/prototype/jurisdictions/certificate.NL.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NO.xml
+++ b/prototype/jurisdictions/certificate.NO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NP.xml
+++ b/prototype/jurisdictions/certificate.NP.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NR.xml
+++ b/prototype/jurisdictions/certificate.NR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NU.xml
+++ b/prototype/jurisdictions/certificate.NU.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.NZ.xml
+++ b/prototype/jurisdictions/certificate.NZ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.OM.xml
+++ b/prototype/jurisdictions/certificate.OM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PA.xml
+++ b/prototype/jurisdictions/certificate.PA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PE.xml
+++ b/prototype/jurisdictions/certificate.PE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PF.xml
+++ b/prototype/jurisdictions/certificate.PF.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PG.xml
+++ b/prototype/jurisdictions/certificate.PG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PH.xml
+++ b/prototype/jurisdictions/certificate.PH.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PK.xml
+++ b/prototype/jurisdictions/certificate.PK.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PL.xml
+++ b/prototype/jurisdictions/certificate.PL.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PM.xml
+++ b/prototype/jurisdictions/certificate.PM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PN.xml
+++ b/prototype/jurisdictions/certificate.PN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PR.xml
+++ b/prototype/jurisdictions/certificate.PR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PS.xml
+++ b/prototype/jurisdictions/certificate.PS.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PT.xml
+++ b/prototype/jurisdictions/certificate.PT.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PW.xml
+++ b/prototype/jurisdictions/certificate.PW.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.PY.xml
+++ b/prototype/jurisdictions/certificate.PY.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.QA.xml
+++ b/prototype/jurisdictions/certificate.QA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.RE.xml
+++ b/prototype/jurisdictions/certificate.RE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.RO.xml
+++ b/prototype/jurisdictions/certificate.RO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.RS.xml
+++ b/prototype/jurisdictions/certificate.RS.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.RU.xml
+++ b/prototype/jurisdictions/certificate.RU.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.RW.xml
+++ b/prototype/jurisdictions/certificate.RW.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SA.xml
+++ b/prototype/jurisdictions/certificate.SA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SB.xml
+++ b/prototype/jurisdictions/certificate.SB.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SC.xml
+++ b/prototype/jurisdictions/certificate.SC.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SD.xml
+++ b/prototype/jurisdictions/certificate.SD.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SE.xml
+++ b/prototype/jurisdictions/certificate.SE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SG.xml
+++ b/prototype/jurisdictions/certificate.SG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SH.xml
+++ b/prototype/jurisdictions/certificate.SH.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SI.xml
+++ b/prototype/jurisdictions/certificate.SI.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SJ.xml
+++ b/prototype/jurisdictions/certificate.SJ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SK.xml
+++ b/prototype/jurisdictions/certificate.SK.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SL.xml
+++ b/prototype/jurisdictions/certificate.SL.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SM.xml
+++ b/prototype/jurisdictions/certificate.SM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SN.xml
+++ b/prototype/jurisdictions/certificate.SN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SO.xml
+++ b/prototype/jurisdictions/certificate.SO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SR.xml
+++ b/prototype/jurisdictions/certificate.SR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SS.xml
+++ b/prototype/jurisdictions/certificate.SS.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.ST.xml
+++ b/prototype/jurisdictions/certificate.ST.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SV.xml
+++ b/prototype/jurisdictions/certificate.SV.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SX.xml
+++ b/prototype/jurisdictions/certificate.SX.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SY.xml
+++ b/prototype/jurisdictions/certificate.SY.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.SZ.xml
+++ b/prototype/jurisdictions/certificate.SZ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TC.xml
+++ b/prototype/jurisdictions/certificate.TC.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TD.xml
+++ b/prototype/jurisdictions/certificate.TD.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TF.xml
+++ b/prototype/jurisdictions/certificate.TF.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TG.xml
+++ b/prototype/jurisdictions/certificate.TG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TH.xml
+++ b/prototype/jurisdictions/certificate.TH.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TJ.xml
+++ b/prototype/jurisdictions/certificate.TJ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TK.xml
+++ b/prototype/jurisdictions/certificate.TK.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TL.xml
+++ b/prototype/jurisdictions/certificate.TL.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TM.xml
+++ b/prototype/jurisdictions/certificate.TM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TN.xml
+++ b/prototype/jurisdictions/certificate.TN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TO.xml
+++ b/prototype/jurisdictions/certificate.TO.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TR.xml
+++ b/prototype/jurisdictions/certificate.TR.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TT.xml
+++ b/prototype/jurisdictions/certificate.TT.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TV.xml
+++ b/prototype/jurisdictions/certificate.TV.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TW.xml
+++ b/prototype/jurisdictions/certificate.TW.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.TZ.xml
+++ b/prototype/jurisdictions/certificate.TZ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.UA.xml
+++ b/prototype/jurisdictions/certificate.UA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.UG.xml
+++ b/prototype/jurisdictions/certificate.UG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.UM.xml
+++ b/prototype/jurisdictions/certificate.UM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.US.xml
+++ b/prototype/jurisdictions/certificate.US.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.UY.xml
+++ b/prototype/jurisdictions/certificate.UY.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.UZ.xml
+++ b/prototype/jurisdictions/certificate.UZ.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.VA.xml
+++ b/prototype/jurisdictions/certificate.VA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.VC.xml
+++ b/prototype/jurisdictions/certificate.VC.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.VE.xml
+++ b/prototype/jurisdictions/certificate.VE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.VG.xml
+++ b/prototype/jurisdictions/certificate.VG.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.VI.xml
+++ b/prototype/jurisdictions/certificate.VI.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.VN.xml
+++ b/prototype/jurisdictions/certificate.VN.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.VU.xml
+++ b/prototype/jurisdictions/certificate.VU.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.WF.xml
+++ b/prototype/jurisdictions/certificate.WF.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.WS.xml
+++ b/prototype/jurisdictions/certificate.WS.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.YE.xml
+++ b/prototype/jurisdictions/certificate.YE.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.YT.xml
+++ b/prototype/jurisdictions/certificate.YT.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.ZA.xml
+++ b/prototype/jurisdictions/certificate.ZA.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.ZM.xml
+++ b/prototype/jurisdictions/certificate.ZM.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/prototype/jurisdictions/certificate.ZW.xml
+++ b/prototype/jurisdictions/certificate.ZW.xml
@@ -213,10 +213,18 @@
 					</option>
 				</radioset>
 			</question>
-			<if test="this.contentRights() !== 'mixedrights'">
+			<if test="this.contentRights() === 'norights'">
+				<question id="explicitWaiver" display="The content has been">
+					<label>Is the content of the data marked as public domain?</label>
+					<yesno yes="marked as public domain"/>
+					<help>Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.</help>
+					<requirement level="standard">You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.</requirement>
+				</question>
+			</if>
+			<if test="this.contentRights() === 'samerights'">
 				<question id="contentLicence" display="The content is available under">
 					<label>Under which licence can others reuse content?</label>
-					<select>
+					<select required="required">
 						<option/>
 						<option value="cc-by">Creative Commons Attribution</option>
 						<option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
@@ -225,12 +233,6 @@
 						<option value="other" display="">Other...</option>
 					</select>
 					<help>Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it's expired, or you've waived them, choose 'Not applicable'.</help>
-					<if test="this.contentRights() === 'samerights'">
-						<requirement test="this.contentLicence() !== ''">You must <strong>license the content of the data</strong> so that it can be reused.</requirement>
-					</if>
-					<if test="this.contentRights() === 'norights'">
-						<requirement test="this.contentLicence() !== ''" level="standard">You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.</requirement>
-					</if>
 				</question>
 				<if test="this.contentLicence() === 'na'">
 					<question id="contentNotApplicable" display="The content in this data is not licensed because">

--- a/surveys/odc_questionnaire.AD.rb
+++ b/surveys/odc_questionnaire.AD.rb
@@ -446,15 +446,35 @@ survey 'AD',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AD',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AD',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AD',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AD',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AD',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AD',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AD',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AD',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AD',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AD',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AE.rb
+++ b/surveys/odc_questionnaire.AE.rb
@@ -446,15 +446,35 @@ survey 'AE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AF.rb
+++ b/surveys/odc_questionnaire.AF.rb
@@ -446,15 +446,35 @@ survey 'AF',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AF',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AF',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AF',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AF',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AF',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AF',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AF',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AF',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AF',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AF',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AG.rb
+++ b/surveys/odc_questionnaire.AG.rb
@@ -446,15 +446,35 @@ survey 'AG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AI.rb
+++ b/surveys/odc_questionnaire.AI.rb
@@ -446,15 +446,35 @@ survey 'AI',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AI',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AI',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AI',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AI',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AI',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AI',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AI',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AI',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AI',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AI',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AL.rb
+++ b/surveys/odc_questionnaire.AL.rb
@@ -446,15 +446,35 @@ survey 'AL',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AL',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AL',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AL',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AL',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AL',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AL',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AL',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AL',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AL',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AL',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AM.rb
+++ b/surveys/odc_questionnaire.AM.rb
@@ -446,15 +446,35 @@ survey 'AM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AO.rb
+++ b/surveys/odc_questionnaire.AO.rb
@@ -446,15 +446,35 @@ survey 'AO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AQ.rb
+++ b/surveys/odc_questionnaire.AQ.rb
@@ -446,15 +446,35 @@ survey 'AQ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AQ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AQ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AQ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AQ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AQ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AQ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AQ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AQ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AQ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AQ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AR.rb
+++ b/surveys/odc_questionnaire.AR.rb
@@ -446,15 +446,35 @@ survey 'AR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AS.rb
+++ b/surveys/odc_questionnaire.AS.rb
@@ -446,15 +446,35 @@ survey 'AS',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AS',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AS',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AS',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AS',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AS',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AS',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AS',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AS',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AS',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AS',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AT.rb
+++ b/surveys/odc_questionnaire.AT.rb
@@ -446,15 +446,35 @@ survey 'AT',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AT',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AT',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AT',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AT',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AT',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AT',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'AT',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'AT',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'AT',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'AT',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AU.rb
+++ b/surveys/odc_questionnaire.AU.rb
@@ -446,15 +446,35 @@ survey 'AU',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AU',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AU',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AU',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AU',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AU',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AU',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AU',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AU',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AU',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AU',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AW.rb
+++ b/surveys/odc_questionnaire.AW.rb
@@ -446,15 +446,35 @@ survey 'AW',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AW',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AW',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AW',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AW',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AW',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AW',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AW',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AW',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AW',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AW',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AX.rb
+++ b/surveys/odc_questionnaire.AX.rb
@@ -446,15 +446,35 @@ survey 'AX',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AX',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AX',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AX',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AX',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AX',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AX',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AX',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AX',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AX',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AX',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.AZ.rb
+++ b/surveys/odc_questionnaire.AZ.rb
@@ -446,15 +446,35 @@ survey 'AZ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'AZ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'AZ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'AZ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'AZ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'AZ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'AZ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'AZ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'AZ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'AZ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'AZ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BA.rb
+++ b/surveys/odc_questionnaire.BA.rb
@@ -446,15 +446,35 @@ survey 'BA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BB.rb
+++ b/surveys/odc_questionnaire.BB.rb
@@ -446,15 +446,35 @@ survey 'BB',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BB',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BB',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BB',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BB',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BB',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BB',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BB',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BB',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BB',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BB',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BD.rb
+++ b/surveys/odc_questionnaire.BD.rb
@@ -446,15 +446,35 @@ survey 'BD',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BD',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BD',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BD',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BD',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BD',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BD',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BD',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BD',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BD',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BD',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BE.rb
+++ b/surveys/odc_questionnaire.BE.rb
@@ -446,15 +446,35 @@ survey 'BE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'BE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'BE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'BE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'BE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BF.rb
+++ b/surveys/odc_questionnaire.BF.rb
@@ -446,15 +446,35 @@ survey 'BF',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BF',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BF',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BF',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BF',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BF',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BF',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BF',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BF',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BF',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BF',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BG.rb
+++ b/surveys/odc_questionnaire.BG.rb
@@ -446,15 +446,35 @@ survey 'BG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'BG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'BG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'BG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'BG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BH.rb
+++ b/surveys/odc_questionnaire.BH.rb
@@ -446,15 +446,35 @@ survey 'BH',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BH',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BH',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BH',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BH',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BH',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BH',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BH',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BH',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BH',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BH',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BI.rb
+++ b/surveys/odc_questionnaire.BI.rb
@@ -446,15 +446,35 @@ survey 'BI',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BI',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BI',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BI',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BI',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BI',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BI',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BI',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BI',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BI',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BI',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BJ.rb
+++ b/surveys/odc_questionnaire.BJ.rb
@@ -446,15 +446,35 @@ survey 'BJ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BJ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BJ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BJ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BJ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BJ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BJ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BJ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BJ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BJ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BJ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BL.rb
+++ b/surveys/odc_questionnaire.BL.rb
@@ -446,15 +446,35 @@ survey 'BL',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BL',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BL',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BL',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BL',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BL',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BL',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BL',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BL',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BL',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BL',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BM.rb
+++ b/surveys/odc_questionnaire.BM.rb
@@ -446,15 +446,35 @@ survey 'BM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BN.rb
+++ b/surveys/odc_questionnaire.BN.rb
@@ -446,15 +446,35 @@ survey 'BN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BO.rb
+++ b/surveys/odc_questionnaire.BO.rb
@@ -446,15 +446,35 @@ survey 'BO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BQ.rb
+++ b/surveys/odc_questionnaire.BQ.rb
@@ -446,15 +446,35 @@ survey 'BQ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BQ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BQ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BQ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BQ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BQ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BQ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BQ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BQ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BQ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BQ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BR.rb
+++ b/surveys/odc_questionnaire.BR.rb
@@ -446,15 +446,35 @@ survey 'BR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BS.rb
+++ b/surveys/odc_questionnaire.BS.rb
@@ -446,15 +446,35 @@ survey 'BS',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BS',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BS',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BS',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BS',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BS',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BS',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BS',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BS',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BS',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BS',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BT.rb
+++ b/surveys/odc_questionnaire.BT.rb
@@ -446,15 +446,35 @@ survey 'BT',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BT',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BT',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BT',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BT',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BT',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BT',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BT',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BT',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BT',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BT',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BV.rb
+++ b/surveys/odc_questionnaire.BV.rb
@@ -446,15 +446,35 @@ survey 'BV',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BV',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BV',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BV',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BV',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BV',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BV',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BV',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BV',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BV',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BV',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BW.rb
+++ b/surveys/odc_questionnaire.BW.rb
@@ -446,15 +446,35 @@ survey 'BW',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BW',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BW',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BW',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BW',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BW',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BW',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BW',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BW',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BW',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BW',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BY.rb
+++ b/surveys/odc_questionnaire.BY.rb
@@ -446,15 +446,35 @@ survey 'BY',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BY',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BY',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BY',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BY',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BY',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BY',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BY',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BY',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BY',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BY',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.BZ.rb
+++ b/surveys/odc_questionnaire.BZ.rb
@@ -446,15 +446,35 @@ survey 'BZ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'BZ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'BZ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'BZ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'BZ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'BZ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'BZ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'BZ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'BZ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'BZ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'BZ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CA.rb
+++ b/surveys/odc_questionnaire.CA.rb
@@ -446,15 +446,35 @@ survey 'CA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CC.rb
+++ b/surveys/odc_questionnaire.CC.rb
@@ -446,15 +446,35 @@ survey 'CC',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CC',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CC',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CC',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CC',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CC',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CC',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CC',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CC',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CC',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CC',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CD.rb
+++ b/surveys/odc_questionnaire.CD.rb
@@ -446,15 +446,35 @@ survey 'CD',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CD',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CD',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CD',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CD',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CD',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CD',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CD',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CD',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CD',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CD',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CF.rb
+++ b/surveys/odc_questionnaire.CF.rb
@@ -446,15 +446,35 @@ survey 'CF',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CF',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CF',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CF',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CF',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CF',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CF',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CF',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CF',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CF',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CF',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CG.rb
+++ b/surveys/odc_questionnaire.CG.rb
@@ -446,15 +446,35 @@ survey 'CG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CH.rb
+++ b/surveys/odc_questionnaire.CH.rb
@@ -446,15 +446,35 @@ survey 'CH',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CH',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CH',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CH',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CH',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CH',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CH',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CH',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CH',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CH',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CH',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CI.rb
+++ b/surveys/odc_questionnaire.CI.rb
@@ -446,15 +446,35 @@ survey 'CI',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CI',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CI',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CI',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CI',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CI',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CI',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CI',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CI',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CI',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CI',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CK.rb
+++ b/surveys/odc_questionnaire.CK.rb
@@ -446,15 +446,35 @@ survey 'CK',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CK',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CK',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CK',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CK',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CK',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CK',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CK',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CK',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CK',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CK',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CL.rb
+++ b/surveys/odc_questionnaire.CL.rb
@@ -446,15 +446,35 @@ survey 'CL',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CL',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CL',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CL',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CL',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CL',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CL',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CL',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CL',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CL',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CL',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CM.rb
+++ b/surveys/odc_questionnaire.CM.rb
@@ -446,15 +446,35 @@ survey 'CM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CN.rb
+++ b/surveys/odc_questionnaire.CN.rb
@@ -446,15 +446,35 @@ survey 'CN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CO.rb
+++ b/surveys/odc_questionnaire.CO.rb
@@ -446,15 +446,35 @@ survey 'CO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CR.rb
+++ b/surveys/odc_questionnaire.CR.rb
@@ -446,15 +446,35 @@ survey 'CR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CU.rb
+++ b/surveys/odc_questionnaire.CU.rb
@@ -446,15 +446,35 @@ survey 'CU',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CU',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CU',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CU',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CU',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CU',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CU',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CU',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CU',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CU',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CU',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CV.rb
+++ b/surveys/odc_questionnaire.CV.rb
@@ -446,15 +446,35 @@ survey 'CV',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CV',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CV',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CV',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CV',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CV',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CV',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CV',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CV',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CV',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CV',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CW.rb
+++ b/surveys/odc_questionnaire.CW.rb
@@ -446,15 +446,35 @@ survey 'CW',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CW',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CW',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CW',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CW',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CW',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CW',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CW',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CW',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CW',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CW',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CX.rb
+++ b/surveys/odc_questionnaire.CX.rb
@@ -446,15 +446,35 @@ survey 'CX',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CX',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CX',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CX',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CX',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CX',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CX',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'CX',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'CX',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'CX',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'CX',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CY.rb
+++ b/surveys/odc_questionnaire.CY.rb
@@ -446,15 +446,35 @@ survey 'CY',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CY',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CY',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CY',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CY',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CY',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CY',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'CY',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'CY',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'CY',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'CY',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.CZ.rb
+++ b/surveys/odc_questionnaire.CZ.rb
@@ -446,15 +446,35 @@ survey 'CZ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'CZ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'CZ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'CZ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'CZ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'CZ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'CZ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'CZ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'CZ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'CZ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'CZ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.DE.rb
+++ b/surveys/odc_questionnaire.DE.rb
@@ -446,15 +446,35 @@ survey 'DE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'DE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'DE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'DE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'DE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'DE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'DE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'DE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'DE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'DE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'DE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.DJ.rb
+++ b/surveys/odc_questionnaire.DJ.rb
@@ -446,15 +446,35 @@ survey 'DJ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'DJ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'DJ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'DJ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'DJ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'DJ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'DJ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'DJ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'DJ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'DJ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'DJ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.DK.rb
+++ b/surveys/odc_questionnaire.DK.rb
@@ -446,15 +446,35 @@ survey 'DK',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'DK',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'DK',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'DK',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'DK',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'DK',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'DK',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'DK',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'DK',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'DK',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'DK',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.DM.rb
+++ b/surveys/odc_questionnaire.DM.rb
@@ -446,15 +446,35 @@ survey 'DM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'DM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'DM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'DM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'DM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'DM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'DM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'DM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'DM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'DM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'DM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.DO.rb
+++ b/surveys/odc_questionnaire.DO.rb
@@ -446,15 +446,35 @@ survey 'DO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'DO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'DO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'DO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'DO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'DO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'DO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'DO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'DO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'DO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'DO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.DZ.rb
+++ b/surveys/odc_questionnaire.DZ.rb
@@ -446,15 +446,35 @@ survey 'DZ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'DZ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'DZ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'DZ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'DZ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'DZ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'DZ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'DZ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'DZ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'DZ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'DZ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.EC.rb
+++ b/surveys/odc_questionnaire.EC.rb
@@ -446,15 +446,35 @@ survey 'EC',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'EC',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'EC',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'EC',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'EC',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'EC',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'EC',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'EC',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'EC',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'EC',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'EC',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.EE.rb
+++ b/surveys/odc_questionnaire.EE.rb
@@ -446,15 +446,35 @@ survey 'EE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'EE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'EE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'EE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'EE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'EE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'EE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'EE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'EE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'EE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'EE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.EG.rb
+++ b/surveys/odc_questionnaire.EG.rb
@@ -446,15 +446,35 @@ survey 'EG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'EG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'EG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'EG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'EG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'EG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'EG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'EG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'EG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'EG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'EG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.EH.rb
+++ b/surveys/odc_questionnaire.EH.rb
@@ -446,15 +446,35 @@ survey 'EH',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'EH',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'EH',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'EH',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'EH',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'EH',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'EH',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'EH',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'EH',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'EH',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'EH',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.ER.rb
+++ b/surveys/odc_questionnaire.ER.rb
@@ -446,15 +446,35 @@ survey 'ER',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'ER',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'ER',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'ER',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'ER',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'ER',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'ER',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'ER',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'ER',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'ER',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'ER',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.ES.rb
+++ b/surveys/odc_questionnaire.ES.rb
@@ -446,15 +446,35 @@ survey 'ES',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'ES',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'ES',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'ES',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'ES',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'ES',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'ES',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'ES',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'ES',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'ES',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'ES',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.ET.rb
+++ b/surveys/odc_questionnaire.ET.rb
@@ -446,15 +446,35 @@ survey 'ET',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'ET',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'ET',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'ET',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'ET',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'ET',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'ET',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'ET',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'ET',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'ET',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'ET',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.FI.rb
+++ b/surveys/odc_questionnaire.FI.rb
@@ -446,15 +446,35 @@ survey 'FI',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'FI',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'FI',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'FI',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'FI',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'FI',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'FI',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'FI',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'FI',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'FI',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'FI',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.FJ.rb
+++ b/surveys/odc_questionnaire.FJ.rb
@@ -446,15 +446,35 @@ survey 'FJ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'FJ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'FJ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'FJ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'FJ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'FJ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'FJ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'FJ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'FJ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'FJ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'FJ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.FK.rb
+++ b/surveys/odc_questionnaire.FK.rb
@@ -446,15 +446,35 @@ survey 'FK',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'FK',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'FK',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'FK',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'FK',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'FK',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'FK',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'FK',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'FK',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'FK',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'FK',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.FM.rb
+++ b/surveys/odc_questionnaire.FM.rb
@@ -446,15 +446,35 @@ survey 'FM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'FM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'FM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'FM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'FM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'FM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'FM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'FM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'FM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'FM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'FM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.FO.rb
+++ b/surveys/odc_questionnaire.FO.rb
@@ -446,15 +446,35 @@ survey 'FO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'FO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'FO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'FO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'FO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'FO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'FO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'FO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'FO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'FO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'FO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.FR.rb
+++ b/surveys/odc_questionnaire.FR.rb
@@ -446,15 +446,35 @@ survey 'FR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'FR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'FR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'FR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'FR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'FR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'FR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'FR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'FR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'FR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'FR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GA.rb
+++ b/surveys/odc_questionnaire.GA.rb
@@ -446,15 +446,35 @@ survey 'GA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GD.rb
+++ b/surveys/odc_questionnaire.GD.rb
@@ -446,15 +446,35 @@ survey 'GD',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GD',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GD',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GD',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GD',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GD',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GD',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GD',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GD',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GD',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GD',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GE.rb
+++ b/surveys/odc_questionnaire.GE.rb
@@ -446,15 +446,35 @@ survey 'GE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GF.rb
+++ b/surveys/odc_questionnaire.GF.rb
@@ -446,15 +446,35 @@ survey 'GF',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GF',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GF',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GF',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GF',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GF',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GF',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GF',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GF',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GF',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GF',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GG.rb
+++ b/surveys/odc_questionnaire.GG.rb
@@ -446,15 +446,35 @@ survey 'GG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GH.rb
+++ b/surveys/odc_questionnaire.GH.rb
@@ -446,15 +446,35 @@ survey 'GH',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GH',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GH',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GH',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GH',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GH',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GH',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GH',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GH',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GH',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GH',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GI.rb
+++ b/surveys/odc_questionnaire.GI.rb
@@ -446,15 +446,35 @@ survey 'GI',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GI',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GI',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GI',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GI',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GI',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GI',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GI',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GI',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GI',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GI',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GL.rb
+++ b/surveys/odc_questionnaire.GL.rb
@@ -446,15 +446,35 @@ survey 'GL',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GL',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GL',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GL',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GL',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GL',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GL',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GL',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GL',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GL',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GL',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GM.rb
+++ b/surveys/odc_questionnaire.GM.rb
@@ -446,15 +446,35 @@ survey 'GM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GN.rb
+++ b/surveys/odc_questionnaire.GN.rb
@@ -446,15 +446,35 @@ survey 'GN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GP.rb
+++ b/surveys/odc_questionnaire.GP.rb
@@ -446,15 +446,35 @@ survey 'GP',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GP',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GP',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GP',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GP',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GP',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GP',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GP',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GP',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GP',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GP',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GQ.rb
+++ b/surveys/odc_questionnaire.GQ.rb
@@ -446,15 +446,35 @@ survey 'GQ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GQ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GQ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GQ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GQ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GQ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GQ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GQ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GQ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GQ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GQ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GR.rb
+++ b/surveys/odc_questionnaire.GR.rb
@@ -446,15 +446,35 @@ survey 'GR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'GR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'GR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'GR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'GR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GS.rb
+++ b/surveys/odc_questionnaire.GS.rb
@@ -446,15 +446,35 @@ survey 'GS',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GS',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GS',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GS',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GS',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GS',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GS',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GS',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GS',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GS',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GS',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GT.rb
+++ b/surveys/odc_questionnaire.GT.rb
@@ -446,15 +446,35 @@ survey 'GT',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GT',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GT',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GT',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GT',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GT',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GT',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GT',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GT',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GT',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GT',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GU.rb
+++ b/surveys/odc_questionnaire.GU.rb
@@ -446,15 +446,35 @@ survey 'GU',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GU',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GU',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GU',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GU',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GU',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GU',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GU',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GU',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GU',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GU',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GW.rb
+++ b/surveys/odc_questionnaire.GW.rb
@@ -446,15 +446,35 @@ survey 'GW',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GW',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GW',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GW',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GW',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GW',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GW',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GW',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GW',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GW',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GW',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.GY.rb
+++ b/surveys/odc_questionnaire.GY.rb
@@ -446,15 +446,35 @@ survey 'GY',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'GY',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'GY',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'GY',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'GY',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'GY',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'GY',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'GY',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'GY',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'GY',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'GY',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.HK.rb
+++ b/surveys/odc_questionnaire.HK.rb
@@ -446,15 +446,35 @@ survey 'HK',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'HK',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'HK',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'HK',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'HK',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'HK',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'HK',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'HK',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'HK',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'HK',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'HK',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.HM.rb
+++ b/surveys/odc_questionnaire.HM.rb
@@ -446,15 +446,35 @@ survey 'HM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'HM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'HM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'HM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'HM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'HM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'HM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'HM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'HM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'HM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'HM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.HN.rb
+++ b/surveys/odc_questionnaire.HN.rb
@@ -446,15 +446,35 @@ survey 'HN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'HN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'HN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'HN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'HN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'HN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'HN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'HN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'HN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'HN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'HN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.HR.rb
+++ b/surveys/odc_questionnaire.HR.rb
@@ -446,15 +446,35 @@ survey 'HR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'HR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'HR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'HR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'HR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'HR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'HR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'HR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'HR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'HR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'HR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.HT.rb
+++ b/surveys/odc_questionnaire.HT.rb
@@ -446,15 +446,35 @@ survey 'HT',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'HT',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'HT',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'HT',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'HT',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'HT',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'HT',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'HT',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'HT',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'HT',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'HT',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.HU.rb
+++ b/surveys/odc_questionnaire.HU.rb
@@ -446,15 +446,35 @@ survey 'HU',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'HU',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'HU',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'HU',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'HU',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'HU',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'HU',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'HU',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'HU',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'HU',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'HU',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.ID.rb
+++ b/surveys/odc_questionnaire.ID.rb
@@ -446,15 +446,35 @@ survey 'ID',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'ID',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'ID',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'ID',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'ID',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'ID',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'ID',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'ID',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'ID',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'ID',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'ID',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.IE.rb
+++ b/surveys/odc_questionnaire.IE.rb
@@ -446,15 +446,35 @@ survey 'IE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'IE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'IE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'IE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'IE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'IE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'IE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'IE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'IE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'IE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'IE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.IL.rb
+++ b/surveys/odc_questionnaire.IL.rb
@@ -446,15 +446,35 @@ survey 'IL',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'IL',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'IL',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'IL',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'IL',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'IL',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'IL',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'IL',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'IL',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'IL',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'IL',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.IM.rb
+++ b/surveys/odc_questionnaire.IM.rb
@@ -446,15 +446,35 @@ survey 'IM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'IM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'IM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'IM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'IM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'IM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'IM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'IM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'IM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'IM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'IM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.IN.rb
+++ b/surveys/odc_questionnaire.IN.rb
@@ -446,15 +446,35 @@ survey 'IN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'IN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'IN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'IN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'IN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'IN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'IN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'IN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'IN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'IN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'IN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.IO.rb
+++ b/surveys/odc_questionnaire.IO.rb
@@ -446,15 +446,35 @@ survey 'IO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'IO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'IO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'IO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'IO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'IO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'IO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'IO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'IO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'IO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'IO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.IQ.rb
+++ b/surveys/odc_questionnaire.IQ.rb
@@ -446,15 +446,35 @@ survey 'IQ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'IQ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'IQ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'IQ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'IQ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'IQ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'IQ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'IQ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'IQ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'IQ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'IQ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.IR.rb
+++ b/surveys/odc_questionnaire.IR.rb
@@ -446,15 +446,35 @@ survey 'IR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'IR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'IR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'IR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'IR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'IR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'IR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'IR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'IR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'IR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'IR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.IS.rb
+++ b/surveys/odc_questionnaire.IS.rb
@@ -446,15 +446,35 @@ survey 'IS',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'IS',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'IS',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'IS',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'IS',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'IS',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'IS',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'IS',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'IS',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'IS',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'IS',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.IT.rb
+++ b/surveys/odc_questionnaire.IT.rb
@@ -446,15 +446,35 @@ survey 'IT',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'IT',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'IT',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'IT',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'IT',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'IT',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'IT',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'IT',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'IT',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'IT',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'IT',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.JE.rb
+++ b/surveys/odc_questionnaire.JE.rb
@@ -446,15 +446,35 @@ survey 'JE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'JE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'JE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'JE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'JE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'JE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'JE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'JE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'JE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'JE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'JE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.JM.rb
+++ b/surveys/odc_questionnaire.JM.rb
@@ -446,15 +446,35 @@ survey 'JM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'JM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'JM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'JM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'JM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'JM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'JM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'JM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'JM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'JM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'JM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.JO.rb
+++ b/surveys/odc_questionnaire.JO.rb
@@ -446,15 +446,35 @@ survey 'JO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'JO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'JO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'JO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'JO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'JO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'JO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'JO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'JO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'JO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'JO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.JP.rb
+++ b/surveys/odc_questionnaire.JP.rb
@@ -446,15 +446,35 @@ survey 'JP',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'JP',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'JP',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'JP',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'JP',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'JP',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'JP',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'JP',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'JP',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'JP',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'JP',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KE.rb
+++ b/surveys/odc_questionnaire.KE.rb
@@ -446,15 +446,35 @@ survey 'KE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KG.rb
+++ b/surveys/odc_questionnaire.KG.rb
@@ -446,15 +446,35 @@ survey 'KG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KH.rb
+++ b/surveys/odc_questionnaire.KH.rb
@@ -446,15 +446,35 @@ survey 'KH',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KH',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KH',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KH',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KH',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KH',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KH',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KH',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KH',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KH',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KH',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KI.rb
+++ b/surveys/odc_questionnaire.KI.rb
@@ -446,15 +446,35 @@ survey 'KI',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KI',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KI',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KI',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KI',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KI',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KI',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KI',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KI',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KI',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KI',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KM.rb
+++ b/surveys/odc_questionnaire.KM.rb
@@ -446,15 +446,35 @@ survey 'KM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KN.rb
+++ b/surveys/odc_questionnaire.KN.rb
@@ -446,15 +446,35 @@ survey 'KN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KP.rb
+++ b/surveys/odc_questionnaire.KP.rb
@@ -446,15 +446,35 @@ survey 'KP',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KP',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KP',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KP',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KP',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KP',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KP',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KP',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KP',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KP',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KP',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KR.rb
+++ b/surveys/odc_questionnaire.KR.rb
@@ -446,15 +446,35 @@ survey 'KR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KW.rb
+++ b/surveys/odc_questionnaire.KW.rb
@@ -446,15 +446,35 @@ survey 'KW',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KW',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KW',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KW',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KW',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KW',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KW',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KW',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KW',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KW',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KW',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KY.rb
+++ b/surveys/odc_questionnaire.KY.rb
@@ -446,15 +446,35 @@ survey 'KY',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KY',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KY',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KY',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KY',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KY',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KY',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KY',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KY',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KY',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KY',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.KZ.rb
+++ b/surveys/odc_questionnaire.KZ.rb
@@ -446,15 +446,35 @@ survey 'KZ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'KZ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'KZ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'KZ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'KZ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'KZ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'KZ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'KZ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'KZ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'KZ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'KZ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LA.rb
+++ b/surveys/odc_questionnaire.LA.rb
@@ -446,15 +446,35 @@ survey 'LA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'LA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'LA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'LA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'LA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LB.rb
+++ b/surveys/odc_questionnaire.LB.rb
@@ -446,15 +446,35 @@ survey 'LB',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LB',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LB',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LB',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LB',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LB',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LB',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'LB',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'LB',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'LB',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'LB',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LC.rb
+++ b/surveys/odc_questionnaire.LC.rb
@@ -446,15 +446,35 @@ survey 'LC',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LC',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LC',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LC',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LC',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LC',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LC',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'LC',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'LC',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'LC',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'LC',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LI.rb
+++ b/surveys/odc_questionnaire.LI.rb
@@ -446,15 +446,35 @@ survey 'LI',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LI',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LI',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LI',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LI',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LI',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LI',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'LI',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'LI',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'LI',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'LI',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LK.rb
+++ b/surveys/odc_questionnaire.LK.rb
@@ -446,15 +446,35 @@ survey 'LK',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LK',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LK',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LK',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LK',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LK',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LK',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'LK',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'LK',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'LK',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'LK',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LR.rb
+++ b/surveys/odc_questionnaire.LR.rb
@@ -446,15 +446,35 @@ survey 'LR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'LR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'LR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'LR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'LR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LS.rb
+++ b/surveys/odc_questionnaire.LS.rb
@@ -446,15 +446,35 @@ survey 'LS',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LS',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LS',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LS',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LS',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LS',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LS',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'LS',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'LS',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'LS',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'LS',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LT.rb
+++ b/surveys/odc_questionnaire.LT.rb
@@ -446,15 +446,35 @@ survey 'LT',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LT',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LT',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LT',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LT',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LT',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LT',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'LT',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'LT',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'LT',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'LT',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LU.rb
+++ b/surveys/odc_questionnaire.LU.rb
@@ -446,15 +446,35 @@ survey 'LU',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LU',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LU',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LU',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LU',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LU',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LU',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'LU',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'LU',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'LU',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'LU',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LV.rb
+++ b/surveys/odc_questionnaire.LV.rb
@@ -446,15 +446,35 @@ survey 'LV',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LV',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LV',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LV',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LV',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LV',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LV',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'LV',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'LV',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'LV',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'LV',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.LY.rb
+++ b/surveys/odc_questionnaire.LY.rb
@@ -446,15 +446,35 @@ survey 'LY',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'LY',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'LY',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'LY',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'LY',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'LY',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'LY',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'LY',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'LY',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'LY',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'LY',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MA.rb
+++ b/surveys/odc_questionnaire.MA.rb
@@ -446,15 +446,35 @@ survey 'MA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MC.rb
+++ b/surveys/odc_questionnaire.MC.rb
@@ -446,15 +446,35 @@ survey 'MC',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MC',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MC',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MC',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MC',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MC',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MC',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MC',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MC',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MC',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MC',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MD.rb
+++ b/surveys/odc_questionnaire.MD.rb
@@ -446,15 +446,35 @@ survey 'MD',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MD',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MD',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MD',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MD',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MD',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MD',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MD',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MD',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MD',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MD',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.ME.rb
+++ b/surveys/odc_questionnaire.ME.rb
@@ -446,15 +446,35 @@ survey 'ME',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'ME',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'ME',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'ME',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'ME',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'ME',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'ME',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'ME',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'ME',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'ME',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'ME',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MF.rb
+++ b/surveys/odc_questionnaire.MF.rb
@@ -446,15 +446,35 @@ survey 'MF',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MF',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MF',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MF',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MF',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MF',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MF',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MF',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MF',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MF',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MF',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MG.rb
+++ b/surveys/odc_questionnaire.MG.rb
@@ -446,15 +446,35 @@ survey 'MG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MH.rb
+++ b/surveys/odc_questionnaire.MH.rb
@@ -446,15 +446,35 @@ survey 'MH',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MH',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MH',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MH',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MH',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MH',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MH',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MH',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MH',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MH',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MH',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MK.rb
+++ b/surveys/odc_questionnaire.MK.rb
@@ -446,15 +446,35 @@ survey 'MK',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MK',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MK',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MK',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MK',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MK',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MK',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MK',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MK',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MK',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MK',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.ML.rb
+++ b/surveys/odc_questionnaire.ML.rb
@@ -446,15 +446,35 @@ survey 'ML',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'ML',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'ML',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'ML',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'ML',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'ML',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'ML',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'ML',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'ML',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'ML',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'ML',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MM.rb
+++ b/surveys/odc_questionnaire.MM.rb
@@ -446,15 +446,35 @@ survey 'MM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MN.rb
+++ b/surveys/odc_questionnaire.MN.rb
@@ -446,15 +446,35 @@ survey 'MN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MO.rb
+++ b/surveys/odc_questionnaire.MO.rb
@@ -446,15 +446,35 @@ survey 'MO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MP.rb
+++ b/surveys/odc_questionnaire.MP.rb
@@ -446,15 +446,35 @@ survey 'MP',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MP',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MP',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MP',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MP',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MP',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MP',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MP',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MP',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MP',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MP',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MQ.rb
+++ b/surveys/odc_questionnaire.MQ.rb
@@ -446,15 +446,35 @@ survey 'MQ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MQ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MQ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MQ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MQ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MQ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MQ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MQ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MQ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MQ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MQ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MR.rb
+++ b/surveys/odc_questionnaire.MR.rb
@@ -446,15 +446,35 @@ survey 'MR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MS.rb
+++ b/surveys/odc_questionnaire.MS.rb
@@ -446,15 +446,35 @@ survey 'MS',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MS',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MS',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MS',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MS',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MS',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MS',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MS',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MS',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MS',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MS',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MT.rb
+++ b/surveys/odc_questionnaire.MT.rb
@@ -446,15 +446,35 @@ survey 'MT',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MT',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MT',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MT',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MT',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MT',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MT',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'MT',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'MT',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'MT',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'MT',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MU.rb
+++ b/surveys/odc_questionnaire.MU.rb
@@ -446,15 +446,35 @@ survey 'MU',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MU',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MU',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MU',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MU',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MU',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MU',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MU',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MU',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MU',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MU',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MV.rb
+++ b/surveys/odc_questionnaire.MV.rb
@@ -446,15 +446,35 @@ survey 'MV',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MV',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MV',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MV',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MV',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MV',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MV',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MV',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MV',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MV',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MV',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MW.rb
+++ b/surveys/odc_questionnaire.MW.rb
@@ -446,15 +446,35 @@ survey 'MW',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MW',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MW',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MW',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MW',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MW',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MW',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MW',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MW',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MW',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MW',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MX.rb
+++ b/surveys/odc_questionnaire.MX.rb
@@ -446,15 +446,35 @@ survey 'MX',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MX',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MX',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MX',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MX',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MX',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MX',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MX',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MX',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MX',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MX',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MY.rb
+++ b/surveys/odc_questionnaire.MY.rb
@@ -446,15 +446,35 @@ survey 'MY',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MY',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MY',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MY',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MY',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MY',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MY',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MY',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MY',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MY',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MY',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.MZ.rb
+++ b/surveys/odc_questionnaire.MZ.rb
@@ -446,15 +446,35 @@ survey 'MZ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'MZ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'MZ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'MZ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'MZ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'MZ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'MZ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'MZ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'MZ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'MZ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'MZ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NA.rb
+++ b/surveys/odc_questionnaire.NA.rb
@@ -446,15 +446,35 @@ survey 'NA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NC.rb
+++ b/surveys/odc_questionnaire.NC.rb
@@ -446,15 +446,35 @@ survey 'NC',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NC',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NC',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NC',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NC',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NC',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NC',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NC',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NC',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NC',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NC',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NE.rb
+++ b/surveys/odc_questionnaire.NE.rb
@@ -446,15 +446,35 @@ survey 'NE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NF.rb
+++ b/surveys/odc_questionnaire.NF.rb
@@ -446,15 +446,35 @@ survey 'NF',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NF',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NF',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NF',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NF',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NF',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NF',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NF',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NF',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NF',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NF',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NG.rb
+++ b/surveys/odc_questionnaire.NG.rb
@@ -446,15 +446,35 @@ survey 'NG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NI.rb
+++ b/surveys/odc_questionnaire.NI.rb
@@ -446,15 +446,35 @@ survey 'NI',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NI',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NI',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NI',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NI',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NI',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NI',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NI',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NI',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NI',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NI',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NL.rb
+++ b/surveys/odc_questionnaire.NL.rb
@@ -446,15 +446,35 @@ survey 'NL',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NL',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NL',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NL',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NL',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NL',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NL',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'NL',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'NL',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'NL',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'NL',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NO.rb
+++ b/surveys/odc_questionnaire.NO.rb
@@ -446,15 +446,35 @@ survey 'NO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NP.rb
+++ b/surveys/odc_questionnaire.NP.rb
@@ -446,15 +446,35 @@ survey 'NP',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NP',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NP',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NP',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NP',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NP',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NP',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NP',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NP',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NP',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NP',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NR.rb
+++ b/surveys/odc_questionnaire.NR.rb
@@ -446,15 +446,35 @@ survey 'NR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NU.rb
+++ b/surveys/odc_questionnaire.NU.rb
@@ -446,15 +446,35 @@ survey 'NU',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NU',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NU',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NU',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NU',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NU',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NU',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NU',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NU',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NU',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NU',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.NZ.rb
+++ b/surveys/odc_questionnaire.NZ.rb
@@ -446,15 +446,35 @@ survey 'NZ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'NZ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'NZ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'NZ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'NZ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'NZ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'NZ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'NZ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'NZ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'NZ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'NZ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.OM.rb
+++ b/surveys/odc_questionnaire.OM.rb
@@ -446,15 +446,35 @@ survey 'OM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'OM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'OM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'OM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'OM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'OM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'OM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'OM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'OM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'OM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'OM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PA.rb
+++ b/surveys/odc_questionnaire.PA.rb
@@ -446,15 +446,35 @@ survey 'PA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PE.rb
+++ b/surveys/odc_questionnaire.PE.rb
@@ -446,15 +446,35 @@ survey 'PE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PF.rb
+++ b/surveys/odc_questionnaire.PF.rb
@@ -446,15 +446,35 @@ survey 'PF',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PF',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PF',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PF',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PF',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PF',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PF',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PF',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PF',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PF',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PF',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PG.rb
+++ b/surveys/odc_questionnaire.PG.rb
@@ -446,15 +446,35 @@ survey 'PG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PH.rb
+++ b/surveys/odc_questionnaire.PH.rb
@@ -446,15 +446,35 @@ survey 'PH',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PH',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PH',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PH',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PH',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PH',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PH',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PH',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PH',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PH',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PH',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PK.rb
+++ b/surveys/odc_questionnaire.PK.rb
@@ -446,15 +446,35 @@ survey 'PK',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PK',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PK',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PK',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PK',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PK',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PK',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PK',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PK',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PK',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PK',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PL.rb
+++ b/surveys/odc_questionnaire.PL.rb
@@ -446,15 +446,35 @@ survey 'PL',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PL',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PL',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PL',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PL',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PL',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PL',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'PL',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'PL',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'PL',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'PL',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PM.rb
+++ b/surveys/odc_questionnaire.PM.rb
@@ -446,15 +446,35 @@ survey 'PM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PN.rb
+++ b/surveys/odc_questionnaire.PN.rb
@@ -446,15 +446,35 @@ survey 'PN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PR.rb
+++ b/surveys/odc_questionnaire.PR.rb
@@ -446,15 +446,35 @@ survey 'PR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PS.rb
+++ b/surveys/odc_questionnaire.PS.rb
@@ -446,15 +446,35 @@ survey 'PS',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PS',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PS',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PS',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PS',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PS',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PS',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PS',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PS',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PS',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PS',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PT.rb
+++ b/surveys/odc_questionnaire.PT.rb
@@ -446,15 +446,35 @@ survey 'PT',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PT',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PT',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PT',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PT',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PT',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PT',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'PT',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'PT',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'PT',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'PT',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PW.rb
+++ b/surveys/odc_questionnaire.PW.rb
@@ -446,15 +446,35 @@ survey 'PW',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PW',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PW',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PW',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PW',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PW',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PW',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PW',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PW',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PW',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PW',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.PY.rb
+++ b/surveys/odc_questionnaire.PY.rb
@@ -446,15 +446,35 @@ survey 'PY',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'PY',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'PY',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'PY',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'PY',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'PY',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'PY',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'PY',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'PY',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'PY',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'PY',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.QA.rb
+++ b/surveys/odc_questionnaire.QA.rb
@@ -446,15 +446,35 @@ survey 'QA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'QA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'QA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'QA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'QA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'QA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'QA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'QA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'QA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'QA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'QA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.RE.rb
+++ b/surveys/odc_questionnaire.RE.rb
@@ -446,15 +446,35 @@ survey 'RE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'RE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'RE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'RE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'RE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'RE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'RE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'RE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'RE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'RE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'RE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.RO.rb
+++ b/surveys/odc_questionnaire.RO.rb
@@ -446,15 +446,35 @@ survey 'RO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'RO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'RO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'RO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'RO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'RO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'RO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'RO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'RO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'RO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'RO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.RS.rb
+++ b/surveys/odc_questionnaire.RS.rb
@@ -446,15 +446,35 @@ survey 'RS',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'RS',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'RS',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'RS',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'RS',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'RS',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'RS',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'RS',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'RS',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'RS',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'RS',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.RU.rb
+++ b/surveys/odc_questionnaire.RU.rb
@@ -446,15 +446,35 @@ survey 'RU',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'RU',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'RU',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'RU',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'RU',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'RU',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'RU',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'RU',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'RU',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'RU',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'RU',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.RW.rb
+++ b/surveys/odc_questionnaire.RW.rb
@@ -446,15 +446,35 @@ survey 'RW',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'RW',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'RW',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'RW',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'RW',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'RW',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'RW',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'RW',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'RW',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'RW',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'RW',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SA.rb
+++ b/surveys/odc_questionnaire.SA.rb
@@ -446,15 +446,35 @@ survey 'SA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SB.rb
+++ b/surveys/odc_questionnaire.SB.rb
@@ -446,15 +446,35 @@ survey 'SB',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SB',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SB',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SB',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SB',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SB',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SB',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SB',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SB',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SB',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SB',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SC.rb
+++ b/surveys/odc_questionnaire.SC.rb
@@ -446,15 +446,35 @@ survey 'SC',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SC',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SC',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SC',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SC',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SC',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SC',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SC',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SC',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SC',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SC',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SD.rb
+++ b/surveys/odc_questionnaire.SD.rb
@@ -446,15 +446,35 @@ survey 'SD',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SD',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SD',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SD',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SD',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SD',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SD',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SD',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SD',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SD',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SD',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SE.rb
+++ b/surveys/odc_questionnaire.SE.rb
@@ -446,15 +446,35 @@ survey 'SE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'SE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'SE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'SE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'SE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SG.rb
+++ b/surveys/odc_questionnaire.SG.rb
@@ -446,15 +446,35 @@ survey 'SG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SH.rb
+++ b/surveys/odc_questionnaire.SH.rb
@@ -446,15 +446,35 @@ survey 'SH',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SH',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SH',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SH',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SH',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SH',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SH',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SH',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SH',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SH',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SH',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SI.rb
+++ b/surveys/odc_questionnaire.SI.rb
@@ -446,15 +446,35 @@ survey 'SI',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SI',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SI',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SI',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SI',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SI',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SI',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'SI',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'SI',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'SI',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'SI',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SJ.rb
+++ b/surveys/odc_questionnaire.SJ.rb
@@ -446,15 +446,35 @@ survey 'SJ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SJ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SJ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SJ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SJ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SJ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SJ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SJ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SJ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SJ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SJ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SK.rb
+++ b/surveys/odc_questionnaire.SK.rb
@@ -446,15 +446,35 @@ survey 'SK',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SK',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SK',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SK',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SK',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SK',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SK',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1478,11 +1482,11 @@ survey 'SK',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1497,7 +1501,7 @@ survey 'SK',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1532,9 +1536,9 @@ survey 'SK',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1594,11 +1598,11 @@ survey 'SK',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SL.rb
+++ b/surveys/odc_questionnaire.SL.rb
@@ -446,15 +446,35 @@ survey 'SL',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SL',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SL',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SL',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SL',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SL',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SL',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SL',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SL',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SL',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SL',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SM.rb
+++ b/surveys/odc_questionnaire.SM.rb
@@ -446,15 +446,35 @@ survey 'SM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SN.rb
+++ b/surveys/odc_questionnaire.SN.rb
@@ -446,15 +446,35 @@ survey 'SN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SO.rb
+++ b/surveys/odc_questionnaire.SO.rb
@@ -446,15 +446,35 @@ survey 'SO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SR.rb
+++ b/surveys/odc_questionnaire.SR.rb
@@ -446,15 +446,35 @@ survey 'SR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SS.rb
+++ b/surveys/odc_questionnaire.SS.rb
@@ -446,15 +446,35 @@ survey 'SS',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SS',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SS',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SS',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SS',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SS',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SS',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SS',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SS',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SS',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SS',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.ST.rb
+++ b/surveys/odc_questionnaire.ST.rb
@@ -446,15 +446,35 @@ survey 'ST',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'ST',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'ST',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'ST',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'ST',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'ST',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'ST',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'ST',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'ST',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'ST',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'ST',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SV.rb
+++ b/surveys/odc_questionnaire.SV.rb
@@ -446,15 +446,35 @@ survey 'SV',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SV',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SV',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SV',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SV',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SV',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SV',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SV',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SV',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SV',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SV',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SX.rb
+++ b/surveys/odc_questionnaire.SX.rb
@@ -446,15 +446,35 @@ survey 'SX',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SX',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SX',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SX',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SX',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SX',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SX',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SX',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SX',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SX',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SX',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SY.rb
+++ b/surveys/odc_questionnaire.SY.rb
@@ -446,15 +446,35 @@ survey 'SY',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SY',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SY',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SY',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SY',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SY',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SY',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SY',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SY',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SY',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SY',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.SZ.rb
+++ b/surveys/odc_questionnaire.SZ.rb
@@ -446,15 +446,35 @@ survey 'SZ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'SZ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'SZ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'SZ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'SZ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'SZ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'SZ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'SZ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'SZ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'SZ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'SZ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TC.rb
+++ b/surveys/odc_questionnaire.TC.rb
@@ -446,15 +446,35 @@ survey 'TC',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TC',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TC',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TC',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TC',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TC',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TC',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TC',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TC',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TC',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TC',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TD.rb
+++ b/surveys/odc_questionnaire.TD.rb
@@ -446,15 +446,35 @@ survey 'TD',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TD',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TD',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TD',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TD',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TD',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TD',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TD',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TD',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TD',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TD',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TF.rb
+++ b/surveys/odc_questionnaire.TF.rb
@@ -446,15 +446,35 @@ survey 'TF',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TF',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TF',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TF',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TF',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TF',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TF',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TF',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TF',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TF',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TF',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TG.rb
+++ b/surveys/odc_questionnaire.TG.rb
@@ -446,15 +446,35 @@ survey 'TG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TH.rb
+++ b/surveys/odc_questionnaire.TH.rb
@@ -446,15 +446,35 @@ survey 'TH',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TH',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TH',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TH',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TH',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TH',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TH',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TH',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TH',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TH',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TH',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TJ.rb
+++ b/surveys/odc_questionnaire.TJ.rb
@@ -446,15 +446,35 @@ survey 'TJ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TJ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TJ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TJ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TJ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TJ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TJ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TJ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TJ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TJ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TJ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TK.rb
+++ b/surveys/odc_questionnaire.TK.rb
@@ -446,15 +446,35 @@ survey 'TK',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TK',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TK',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TK',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TK',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TK',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TK',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TK',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TK',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TK',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TK',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TL.rb
+++ b/surveys/odc_questionnaire.TL.rb
@@ -446,15 +446,35 @@ survey 'TL',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TL',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TL',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TL',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TL',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TL',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TL',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TL',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TL',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TL',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TL',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TM.rb
+++ b/surveys/odc_questionnaire.TM.rb
@@ -446,15 +446,35 @@ survey 'TM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TN.rb
+++ b/surveys/odc_questionnaire.TN.rb
@@ -446,15 +446,35 @@ survey 'TN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TO.rb
+++ b/surveys/odc_questionnaire.TO.rb
@@ -446,15 +446,35 @@ survey 'TO',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TO',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TO',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TO',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TO',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TO',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TO',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TO',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TO',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TO',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TO',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TR.rb
+++ b/surveys/odc_questionnaire.TR.rb
@@ -446,15 +446,35 @@ survey 'TR',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TR',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TR',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TR',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TR',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TR',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TR',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TR',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TR',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TR',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TR',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TT.rb
+++ b/surveys/odc_questionnaire.TT.rb
@@ -446,15 +446,35 @@ survey 'TT',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TT',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TT',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TT',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TT',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TT',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TT',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TT',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TT',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TT',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TT',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TV.rb
+++ b/surveys/odc_questionnaire.TV.rb
@@ -446,15 +446,35 @@ survey 'TV',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TV',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TV',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TV',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TV',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TV',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TV',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TV',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TV',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TV',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TV',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TW.rb
+++ b/surveys/odc_questionnaire.TW.rb
@@ -446,15 +446,35 @@ survey 'TW',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TW',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TW',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TW',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TW',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TW',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TW',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TW',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TW',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TW',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TW',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.TZ.rb
+++ b/surveys/odc_questionnaire.TZ.rb
@@ -446,15 +446,35 @@ survey 'TZ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'TZ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'TZ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'TZ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'TZ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'TZ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'TZ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'TZ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'TZ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'TZ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'TZ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.UA.rb
+++ b/surveys/odc_questionnaire.UA.rb
@@ -446,15 +446,35 @@ survey 'UA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'UA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'UA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'UA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'UA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'UA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'UA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'UA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'UA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'UA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'UA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.UG.rb
+++ b/surveys/odc_questionnaire.UG.rb
@@ -446,15 +446,35 @@ survey 'UG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'UG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'UG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'UG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'UG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'UG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'UG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'UG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'UG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'UG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'UG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.UK.rb
+++ b/surveys/odc_questionnaire.UK.rb
@@ -448,15 +448,35 @@ survey 'GB',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -470,29 +490,13 @@ survey 'GB',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -512,7 +516,7 @@ survey 'GB',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -526,7 +530,7 @@ survey 'GB',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -542,7 +546,7 @@ survey 'GB',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -555,7 +559,7 @@ survey 'GB',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -569,17 +573,17 @@ survey 'GB',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1486,11 +1490,11 @@ survey 'GB',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_15']
+      :requirement => ['basic_9', 'pilot_15']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1505,7 +1509,7 @@ survey 'GB',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1540,9 +1544,9 @@ survey 'GB',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1602,11 +1606,11 @@ survey 'GB',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.UM.rb
+++ b/surveys/odc_questionnaire.UM.rb
@@ -446,15 +446,35 @@ survey 'UM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'UM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'UM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'UM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'UM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'UM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'UM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'UM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'UM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'UM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'UM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.US.rb
+++ b/surveys/odc_questionnaire.US.rb
@@ -446,15 +446,35 @@ survey 'US',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'US',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'US',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'US',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'US',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'US',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'US',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'US',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'US',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'US',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'US',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.UY.rb
+++ b/surveys/odc_questionnaire.UY.rb
@@ -446,15 +446,35 @@ survey 'UY',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'UY',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'UY',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'UY',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'UY',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'UY',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'UY',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'UY',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'UY',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'UY',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'UY',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.UZ.rb
+++ b/surveys/odc_questionnaire.UZ.rb
@@ -446,15 +446,35 @@ survey 'UZ',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'UZ',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'UZ',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'UZ',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'UZ',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'UZ',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'UZ',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'UZ',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'UZ',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'UZ',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'UZ',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.VA.rb
+++ b/surveys/odc_questionnaire.VA.rb
@@ -446,15 +446,35 @@ survey 'VA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'VA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'VA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'VA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'VA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'VA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'VA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'VA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'VA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'VA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'VA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.VC.rb
+++ b/surveys/odc_questionnaire.VC.rb
@@ -446,15 +446,35 @@ survey 'VC',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'VC',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'VC',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'VC',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'VC',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'VC',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'VC',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'VC',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'VC',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'VC',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'VC',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.VE.rb
+++ b/surveys/odc_questionnaire.VE.rb
@@ -446,15 +446,35 @@ survey 'VE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'VE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'VE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'VE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'VE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'VE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'VE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'VE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'VE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'VE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'VE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.VG.rb
+++ b/surveys/odc_questionnaire.VG.rb
@@ -446,15 +446,35 @@ survey 'VG',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'VG',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'VG',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'VG',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'VG',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'VG',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'VG',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'VG',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'VG',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'VG',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'VG',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.VI.rb
+++ b/surveys/odc_questionnaire.VI.rb
@@ -446,15 +446,35 @@ survey 'VI',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'VI',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'VI',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'VI',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'VI',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'VI',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'VI',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'VI',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'VI',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'VI',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'VI',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.VN.rb
+++ b/surveys/odc_questionnaire.VN.rb
@@ -446,15 +446,35 @@ survey 'VN',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'VN',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'VN',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'VN',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'VN',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'VN',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'VN',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'VN',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'VN',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'VN',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'VN',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.VU.rb
+++ b/surveys/odc_questionnaire.VU.rb
@@ -446,15 +446,35 @@ survey 'VU',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'VU',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'VU',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'VU',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'VU',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'VU',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'VU',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'VU',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'VU',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'VU',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'VU',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.WF.rb
+++ b/surveys/odc_questionnaire.WF.rb
@@ -446,15 +446,35 @@ survey 'WF',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'WF',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'WF',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'WF',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'WF',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'WF',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'WF',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'WF',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'WF',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'WF',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'WF',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.WS.rb
+++ b/surveys/odc_questionnaire.WS.rb
@@ -446,15 +446,35 @@ survey 'WS',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'WS',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'WS',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'WS',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'WS',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'WS',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'WS',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'WS',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'WS',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'WS',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'WS',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.YE.rb
+++ b/surveys/odc_questionnaire.YE.rb
@@ -446,15 +446,35 @@ survey 'YE',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'YE',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'YE',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'YE',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'YE',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'YE',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'YE',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'YE',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'YE',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'YE',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'YE',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.YT.rb
+++ b/surveys/odc_questionnaire.YT.rb
@@ -446,15 +446,35 @@ survey 'YT',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'YT',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'YT',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'YT',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'YT',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'YT',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'YT',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'YT',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'YT',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'YT',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'YT',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.ZA.rb
+++ b/surveys/odc_questionnaire.ZA.rb
@@ -446,15 +446,35 @@ survey 'ZA',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'ZA',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'ZA',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'ZA',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'ZA',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'ZA',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'ZA',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'ZA',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'ZA',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'ZA',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'ZA',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.ZM.rb
+++ b/surveys/odc_questionnaire.ZM.rb
@@ -446,15 +446,35 @@ survey 'ZM',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'ZM',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'ZM',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'ZM',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'ZM',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'ZM',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'ZM',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'ZM',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'ZM',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'ZM',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'ZM',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/odc_questionnaire.ZW.rb
+++ b/surveys/odc_questionnaire.ZW.rb
@@ -446,15 +446,35 @@ survey 'ZW',
       :text_as_statement => '',
       :help_text => 'In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too.'
 
+    q_explicitWaiver 'Is the content of the data marked as public domain?',
+      :display_on_certificate => true,
+      :text_as_statement => 'The content has been',
+      :help_text => 'Content can be marked as public domain using the <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused.',
+      :pick => :one
+    dependency :rule => 'A'
+    condition_A :q_contentRights, '==', :a_norights
+    a_false 'no',
+      :text_as_statement => ''
+    a_true 'yes',
+      :text_as_statement => 'marked as public domain',
+      :requirement => ['standard_3']
+
+    label_standard_3 'You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it.',
+      :custom_renderer => '/partials/requirement_standard',
+      :requirement => 'standard_3'
+    dependency :rule => 'A and B'
+    condition_A :q_contentRights, '==', :a_norights
+    condition_B :q_explicitWaiver, '==', :a_false
+
     q_contentLicence 'Under which licence can others reuse content?',
       :display_on_certificate => true,
       :text_as_statement => 'The content is available under',
       :help_text => 'Remember that whoever spends intellectual effort creating content automatically gets rights over it but creative content does not include facts. So people need a waiver or a licence which proves that they can use the content and explains how they can do that legally. We list the most common licenses here; if there is no copyright in the content, it\'s expired, or you\'ve waived them, choose \'Not applicable\'.',
-      :requirement => ['basic_8', 'standard_3'],
       :pick => :one,
+      :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     a_cc_by 'Creative Commons Attribution',
       :text_as_statement => 'Creative Commons Attribution'
     a_cc_by_sa 'Creative Commons Attribution Share-Alike',
@@ -466,29 +486,13 @@ survey 'ZW',
     a_other 'Other...',
       :text_as_statement => ''
 
-    label_basic_8 'You must <strong>license the content of the data</strong> so that it can be reused.',
-      :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_8'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_samerights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
-    label_standard_3 'You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it.',
-      :custom_renderer => '/partials/requirement_standard',
-      :requirement => 'standard_3'
-    dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
-    condition_B :q_contentRights, '==', :a_norights
-    condition_C :q_contentLicence, '==', {:string_value => '', :answer_reference => '1'}
-
     q_contentNotApplicable 'Why doesn\'t a licence apply to the content of the data?',
       :display_on_certificate => true,
       :text_as_statement => 'The content in this data is not licensed because',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     a_norights 'there is no copyright in the content of this data',
       :text_as_statement => 'there is no copyright',
@@ -508,7 +512,7 @@ survey 'ZW',
       :required => :required,
       :display_type => 'dropdown'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     a_cc0 'Creative Commons CCZero',
@@ -522,7 +526,7 @@ survey 'ZW',
       :help_text => 'Give a URL to your own publicly available waiver so people can check that it does waive your copyright.',
       :required => :required
     dependency :rule => 'A and B and C and D'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_na
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
@@ -538,7 +542,7 @@ survey 'ZW',
       :help_text => 'If you use a different licence, we need its name so people can see it on your Open Data Certificate.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence Name',
       :string,
@@ -551,7 +555,7 @@ survey 'ZW',
       :help_text => 'Give a URL to the licence, so people can see it on your Open Data Certificate and check that it\'s publicly available.',
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
       :string,
@@ -565,17 +569,17 @@ survey 'ZW',
       :pick => :one,
       :required => :required
     dependency :rule => 'A and B'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_false 'no'
     a_true 'yes',
-      :requirement => ['basic_9']
+      :requirement => ['basic_8']
 
-    label_basic_9 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
+    label_basic_8 'You must <strong>publish open data under an open licence</strong> so that people can use it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_9'
+      :requirement => 'basic_8'
     dependency :rule => 'A and B and C'
-    condition_A :q_contentRights, '!=', :a_mixedrights
+    condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     condition_C :q_otherContentLicenceOpen, '==', :a_false
 
@@ -1395,11 +1399,11 @@ survey 'ZW',
       :string,
       :input_type => :url,
       :placeholder => 'Dataset URL',
-      :requirement => ['basic_10', 'pilot_13']
+      :requirement => ['basic_9', 'pilot_13']
 
-    label_basic_10 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
+    label_basic_9 'You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_10'
+      :requirement => 'basic_9'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_oneoff
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1414,7 +1418,7 @@ survey 'ZW',
     condition_C :q_datasetUrl, '==', {:string_value => '', :answer_reference => '1'}
 
     q_versionManagement 'How do you publish a series of the same dataset?',
-      :requirement => ['basic_11'],
+      :requirement => ['basic_10'],
       :pick => :any
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_series
@@ -1449,9 +1453,9 @@ survey 'ZW',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '!=', :a_list
 
-    label_basic_11 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
+    label_basic_10 'You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_11'
+      :requirement => 'basic_10'
     dependency :rule => 'A and (B and C and D and E)'
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}
@@ -1511,11 +1515,11 @@ survey 'ZW',
       :string,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
-      :requirement => ['basic_12', 'standard_27']
+      :requirement => ['basic_11', 'standard_27']
 
-    label_basic_12 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
+    label_basic_11 'You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it.',
       :custom_renderer => '/partials/requirement_basic',
-      :requirement => 'basic_12'
+      :requirement => 'basic_11'
     dependency :rule => 'A and B and C'
     condition_A :q_releaseType, '==', :a_service
     condition_B :q_documentationUrl, '==', {:string_value => '', :answer_reference => '1'}

--- a/surveys/translations/odc.AD.en.yml
+++ b/surveys/translations/odc.AD.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AE.en.yml
+++ b/surveys/translations/odc.AE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AF.en.yml
+++ b/surveys/translations/odc.AF.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AG.en.yml
+++ b/surveys/translations/odc.AG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AI.en.yml
+++ b/surveys/translations/odc.AI.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AL.en.yml
+++ b/surveys/translations/odc.AL.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AM.en.yml
+++ b/surveys/translations/odc.AM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AO.en.yml
+++ b/surveys/translations/odc.AO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AQ.en.yml
+++ b/surveys/translations/odc.AQ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AR.en.yml
+++ b/surveys/translations/odc.AR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AS.en.yml
+++ b/surveys/translations/odc.AS.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AT.en.yml
+++ b/surveys/translations/odc.AT.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AU.en.yml
+++ b/surveys/translations/odc.AU.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AW.en.yml
+++ b/surveys/translations/odc.AW.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AX.en.yml
+++ b/surveys/translations/odc.AX.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.AZ.en.yml
+++ b/surveys/translations/odc.AZ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BA.en.yml
+++ b/surveys/translations/odc.BA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BB.en.yml
+++ b/surveys/translations/odc.BB.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BD.en.yml
+++ b/surveys/translations/odc.BD.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BE.en.yml
+++ b/surveys/translations/odc.BE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BF.en.yml
+++ b/surveys/translations/odc.BF.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BG.en.yml
+++ b/surveys/translations/odc.BG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BH.en.yml
+++ b/surveys/translations/odc.BH.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BI.en.yml
+++ b/surveys/translations/odc.BI.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BJ.en.yml
+++ b/surveys/translations/odc.BJ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BL.en.yml
+++ b/surveys/translations/odc.BL.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BM.en.yml
+++ b/surveys/translations/odc.BM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BN.en.yml
+++ b/surveys/translations/odc.BN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BO.en.yml
+++ b/surveys/translations/odc.BO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BQ.en.yml
+++ b/surveys/translations/odc.BQ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BR.en.yml
+++ b/surveys/translations/odc.BR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BS.en.yml
+++ b/surveys/translations/odc.BS.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BT.en.yml
+++ b/surveys/translations/odc.BT.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BV.en.yml
+++ b/surveys/translations/odc.BV.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BW.en.yml
+++ b/surveys/translations/odc.BW.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BY.en.yml
+++ b/surveys/translations/odc.BY.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.BZ.en.yml
+++ b/surveys/translations/odc.BZ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CA.en.yml
+++ b/surveys/translations/odc.CA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CC.en.yml
+++ b/surveys/translations/odc.CC.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CD.en.yml
+++ b/surveys/translations/odc.CD.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CF.en.yml
+++ b/surveys/translations/odc.CF.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CG.en.yml
+++ b/surveys/translations/odc.CG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CH.en.yml
+++ b/surveys/translations/odc.CH.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CI.en.yml
+++ b/surveys/translations/odc.CI.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CK.en.yml
+++ b/surveys/translations/odc.CK.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CL.en.yml
+++ b/surveys/translations/odc.CL.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CM.en.yml
+++ b/surveys/translations/odc.CM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CN.en.yml
+++ b/surveys/translations/odc.CN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CO.en.yml
+++ b/surveys/translations/odc.CO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CR.en.yml
+++ b/surveys/translations/odc.CR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CU.en.yml
+++ b/surveys/translations/odc.CU.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CV.en.yml
+++ b/surveys/translations/odc.CV.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CW.en.yml
+++ b/surveys/translations/odc.CW.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CX.en.yml
+++ b/surveys/translations/odc.CX.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CY.en.yml
+++ b/surveys/translations/odc.CY.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.CZ.en.yml
+++ b/surveys/translations/odc.CZ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.DE.en.yml
+++ b/surveys/translations/odc.DE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.DJ.en.yml
+++ b/surveys/translations/odc.DJ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.DK.en.yml
+++ b/surveys/translations/odc.DK.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.DM.en.yml
+++ b/surveys/translations/odc.DM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.DO.en.yml
+++ b/surveys/translations/odc.DO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.DZ.en.yml
+++ b/surveys/translations/odc.DZ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.EC.en.yml
+++ b/surveys/translations/odc.EC.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.EE.en.yml
+++ b/surveys/translations/odc.EE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.EG.en.yml
+++ b/surveys/translations/odc.EG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.EH.en.yml
+++ b/surveys/translations/odc.EH.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.ER.en.yml
+++ b/surveys/translations/odc.ER.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.ES.en.yml
+++ b/surveys/translations/odc.ES.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.ET.en.yml
+++ b/surveys/translations/odc.ET.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.FI.en.yml
+++ b/surveys/translations/odc.FI.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.FJ.en.yml
+++ b/surveys/translations/odc.FJ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.FK.en.yml
+++ b/surveys/translations/odc.FK.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.FM.en.yml
+++ b/surveys/translations/odc.FM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.FO.en.yml
+++ b/surveys/translations/odc.FO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.FR.en.yml
+++ b/surveys/translations/odc.FR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GA.en.yml
+++ b/surveys/translations/odc.GA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GD.en.yml
+++ b/surveys/translations/odc.GD.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GE.en.yml
+++ b/surveys/translations/odc.GE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GF.en.yml
+++ b/surveys/translations/odc.GF.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GG.en.yml
+++ b/surveys/translations/odc.GG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GH.en.yml
+++ b/surveys/translations/odc.GH.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GI.en.yml
+++ b/surveys/translations/odc.GI.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GL.en.yml
+++ b/surveys/translations/odc.GL.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GM.en.yml
+++ b/surveys/translations/odc.GM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GN.en.yml
+++ b/surveys/translations/odc.GN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GP.en.yml
+++ b/surveys/translations/odc.GP.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GQ.en.yml
+++ b/surveys/translations/odc.GQ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GR.en.yml
+++ b/surveys/translations/odc.GR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GS.en.yml
+++ b/surveys/translations/odc.GS.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GT.en.yml
+++ b/surveys/translations/odc.GT.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GU.en.yml
+++ b/surveys/translations/odc.GU.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GW.en.yml
+++ b/surveys/translations/odc.GW.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.GY.en.yml
+++ b/surveys/translations/odc.GY.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.HK.en.yml
+++ b/surveys/translations/odc.HK.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.HM.en.yml
+++ b/surveys/translations/odc.HM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.HN.en.yml
+++ b/surveys/translations/odc.HN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.HR.en.yml
+++ b/surveys/translations/odc.HR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.HT.en.yml
+++ b/surveys/translations/odc.HT.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.HU.en.yml
+++ b/surveys/translations/odc.HU.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.ID.en.yml
+++ b/surveys/translations/odc.ID.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.IE.en.yml
+++ b/surveys/translations/odc.IE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.IL.en.yml
+++ b/surveys/translations/odc.IL.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.IM.en.yml
+++ b/surveys/translations/odc.IM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.IN.en.yml
+++ b/surveys/translations/odc.IN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.IO.en.yml
+++ b/surveys/translations/odc.IO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.IQ.en.yml
+++ b/surveys/translations/odc.IQ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.IR.en.yml
+++ b/surveys/translations/odc.IR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.IS.en.yml
+++ b/surveys/translations/odc.IS.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.IT.en.yml
+++ b/surveys/translations/odc.IT.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.JE.en.yml
+++ b/surveys/translations/odc.JE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.JM.en.yml
+++ b/surveys/translations/odc.JM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.JO.en.yml
+++ b/surveys/translations/odc.JO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.JP.en.yml
+++ b/surveys/translations/odc.JP.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KE.en.yml
+++ b/surveys/translations/odc.KE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KG.en.yml
+++ b/surveys/translations/odc.KG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KH.en.yml
+++ b/surveys/translations/odc.KH.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KI.en.yml
+++ b/surveys/translations/odc.KI.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KM.en.yml
+++ b/surveys/translations/odc.KM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KN.en.yml
+++ b/surveys/translations/odc.KN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KP.en.yml
+++ b/surveys/translations/odc.KP.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KR.en.yml
+++ b/surveys/translations/odc.KR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KW.en.yml
+++ b/surveys/translations/odc.KW.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KY.en.yml
+++ b/surveys/translations/odc.KY.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.KZ.en.yml
+++ b/surveys/translations/odc.KZ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LA.en.yml
+++ b/surveys/translations/odc.LA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LB.en.yml
+++ b/surveys/translations/odc.LB.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LC.en.yml
+++ b/surveys/translations/odc.LC.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LI.en.yml
+++ b/surveys/translations/odc.LI.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LK.en.yml
+++ b/surveys/translations/odc.LK.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LR.en.yml
+++ b/surveys/translations/odc.LR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LS.en.yml
+++ b/surveys/translations/odc.LS.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LT.en.yml
+++ b/surveys/translations/odc.LT.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LU.en.yml
+++ b/surveys/translations/odc.LU.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LV.en.yml
+++ b/surveys/translations/odc.LV.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.LY.en.yml
+++ b/surveys/translations/odc.LY.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MA.en.yml
+++ b/surveys/translations/odc.MA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MC.en.yml
+++ b/surveys/translations/odc.MC.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MD.en.yml
+++ b/surveys/translations/odc.MD.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.ME.en.yml
+++ b/surveys/translations/odc.ME.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MF.en.yml
+++ b/surveys/translations/odc.MF.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MG.en.yml
+++ b/surveys/translations/odc.MG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MH.en.yml
+++ b/surveys/translations/odc.MH.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MK.en.yml
+++ b/surveys/translations/odc.MK.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.ML.en.yml
+++ b/surveys/translations/odc.ML.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MM.en.yml
+++ b/surveys/translations/odc.MM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MN.en.yml
+++ b/surveys/translations/odc.MN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MO.en.yml
+++ b/surveys/translations/odc.MO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MP.en.yml
+++ b/surveys/translations/odc.MP.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MQ.en.yml
+++ b/surveys/translations/odc.MQ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MR.en.yml
+++ b/surveys/translations/odc.MR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MS.en.yml
+++ b/surveys/translations/odc.MS.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MT.en.yml
+++ b/surveys/translations/odc.MT.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MU.en.yml
+++ b/surveys/translations/odc.MU.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MV.en.yml
+++ b/surveys/translations/odc.MV.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MW.en.yml
+++ b/surveys/translations/odc.MW.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MX.en.yml
+++ b/surveys/translations/odc.MX.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MY.en.yml
+++ b/surveys/translations/odc.MY.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.MZ.en.yml
+++ b/surveys/translations/odc.MZ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NA.en.yml
+++ b/surveys/translations/odc.NA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NC.en.yml
+++ b/surveys/translations/odc.NC.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NE.en.yml
+++ b/surveys/translations/odc.NE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NF.en.yml
+++ b/surveys/translations/odc.NF.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NG.en.yml
+++ b/surveys/translations/odc.NG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NI.en.yml
+++ b/surveys/translations/odc.NI.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NL.en.yml
+++ b/surveys/translations/odc.NL.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NO.en.yml
+++ b/surveys/translations/odc.NO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NP.en.yml
+++ b/surveys/translations/odc.NP.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NR.en.yml
+++ b/surveys/translations/odc.NR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NU.en.yml
+++ b/surveys/translations/odc.NU.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.NZ.en.yml
+++ b/surveys/translations/odc.NZ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.OM.en.yml
+++ b/surveys/translations/odc.OM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PA.en.yml
+++ b/surveys/translations/odc.PA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PE.en.yml
+++ b/surveys/translations/odc.PE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PF.en.yml
+++ b/surveys/translations/odc.PF.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PG.en.yml
+++ b/surveys/translations/odc.PG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PH.en.yml
+++ b/surveys/translations/odc.PH.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PK.en.yml
+++ b/surveys/translations/odc.PK.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PL.en.yml
+++ b/surveys/translations/odc.PL.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PM.en.yml
+++ b/surveys/translations/odc.PM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PN.en.yml
+++ b/surveys/translations/odc.PN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PR.en.yml
+++ b/surveys/translations/odc.PR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PS.en.yml
+++ b/surveys/translations/odc.PS.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PT.en.yml
+++ b/surveys/translations/odc.PT.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PW.en.yml
+++ b/surveys/translations/odc.PW.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.PY.en.yml
+++ b/surveys/translations/odc.PY.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.QA.en.yml
+++ b/surveys/translations/odc.QA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.RE.en.yml
+++ b/surveys/translations/odc.RE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.RO.en.yml
+++ b/surveys/translations/odc.RO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.RS.en.yml
+++ b/surveys/translations/odc.RS.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.RU.en.yml
+++ b/surveys/translations/odc.RU.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.RW.en.yml
+++ b/surveys/translations/odc.RW.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SA.en.yml
+++ b/surveys/translations/odc.SA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SB.en.yml
+++ b/surveys/translations/odc.SB.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SC.en.yml
+++ b/surveys/translations/odc.SC.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SD.en.yml
+++ b/surveys/translations/odc.SD.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SE.en.yml
+++ b/surveys/translations/odc.SE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SG.en.yml
+++ b/surveys/translations/odc.SG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SH.en.yml
+++ b/surveys/translations/odc.SH.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SI.en.yml
+++ b/surveys/translations/odc.SI.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SJ.en.yml
+++ b/surveys/translations/odc.SJ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SK.en.yml
+++ b/surveys/translations/odc.SK.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1248,11 +1259,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1342,7 +1351,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1352,9 +1361,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SL.en.yml
+++ b/surveys/translations/odc.SL.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SM.en.yml
+++ b/surveys/translations/odc.SM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SN.en.yml
+++ b/surveys/translations/odc.SN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SO.en.yml
+++ b/surveys/translations/odc.SO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SR.en.yml
+++ b/surveys/translations/odc.SR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SS.en.yml
+++ b/surveys/translations/odc.SS.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.ST.en.yml
+++ b/surveys/translations/odc.ST.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SV.en.yml
+++ b/surveys/translations/odc.SV.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SX.en.yml
+++ b/surveys/translations/odc.SX.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SY.en.yml
+++ b/surveys/translations/odc.SY.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.SZ.en.yml
+++ b/surveys/translations/odc.SZ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TC.en.yml
+++ b/surveys/translations/odc.TC.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TD.en.yml
+++ b/surveys/translations/odc.TD.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TF.en.yml
+++ b/surveys/translations/odc.TF.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TG.en.yml
+++ b/surveys/translations/odc.TG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TH.en.yml
+++ b/surveys/translations/odc.TH.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TJ.en.yml
+++ b/surveys/translations/odc.TJ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TK.en.yml
+++ b/surveys/translations/odc.TK.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TL.en.yml
+++ b/surveys/translations/odc.TL.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TM.en.yml
+++ b/surveys/translations/odc.TM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TN.en.yml
+++ b/surveys/translations/odc.TN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TO.en.yml
+++ b/surveys/translations/odc.TO.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TR.en.yml
+++ b/surveys/translations/odc.TR.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TT.en.yml
+++ b/surveys/translations/odc.TT.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TV.en.yml
+++ b/surveys/translations/odc.TV.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TW.en.yml
+++ b/surveys/translations/odc.TW.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.TZ.en.yml
+++ b/surveys/translations/odc.TZ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.UA.en.yml
+++ b/surveys/translations/odc.UA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.UG.en.yml
+++ b/surveys/translations/odc.UG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.UK.en.yml
+++ b/surveys/translations/odc.UK.en.yml
@@ -270,6 +270,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1254,11 +1265,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, database rights, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1348,7 +1357,7 @@ labels:
   exemplar_12:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_15:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1358,9 +1367,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.UM.en.yml
+++ b/surveys/translations/odc.UM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.US.en.yml
+++ b/surveys/translations/odc.US.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.UY.en.yml
+++ b/surveys/translations/odc.UY.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.UZ.en.yml
+++ b/surveys/translations/odc.UZ.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.VA.en.yml
+++ b/surveys/translations/odc.VA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.VC.en.yml
+++ b/surveys/translations/odc.VC.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.VE.en.yml
+++ b/surveys/translations/odc.VE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.VG.en.yml
+++ b/surveys/translations/odc.VG.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.VI.en.yml
+++ b/surveys/translations/odc.VI.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.VN.en.yml
+++ b/surveys/translations/odc.VN.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.VU.en.yml
+++ b/surveys/translations/odc.VU.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.WF.en.yml
+++ b/surveys/translations/odc.WF.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.WS.en.yml
+++ b/surveys/translations/odc.WS.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.YE.en.yml
+++ b/surveys/translations/odc.YE.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.YT.en.yml
+++ b/surveys/translations/odc.YT.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.ZA.en.yml
+++ b/surveys/translations/odc.ZA.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.ZM.en.yml
+++ b/surveys/translations/odc.ZM.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."

--- a/surveys/translations/odc.ZW.en.yml
+++ b/surveys/translations/odc.ZW.en.yml
@@ -267,6 +267,17 @@ questions:
         text: "yes, and the rights are held by different people or organisations"
         help_text: "In some data, the rights in different records are held by different people or organisations. Information about rights needs to be kept in the data too."
         text_as_statement: ""
+  explicitWaiver:
+    text: "Is the content of the data marked as public domain?"
+    text_as_statement: "The content has been"
+    help_text: "Content can be marked as public domain using the <a href=\"http://creativecommons.org/publicdomain/\">Creative Commons Public Domain Mark</a>. This helps people know that it can be freely reused."
+    answers:
+      a_false:
+        text: no
+        text_as_statement: ""
+      a_true:
+        text: yes
+        text_as_statement: "marked as public domain"
   contentLicence:
     text: "Under which licence can others reuse content?"
     text_as_statement: "The content is available under"
@@ -1218,11 +1229,9 @@ labels:
     text: "You should <strong>publish a rights statement</strong> that details copyright, licensing and how people should give attribution to the data."
   basic_7:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
-  basic_8:
-    text: "You must <strong>license the content of the data</strong> so that it can be reused."
   standard_3:
-    text: "You should <strong>license the content of the data</strong> with an open licence, so reusers know they can do anything with it."
-  basic_9:
+    text: "You should <strong>mark public domain content as public domain</strong> so that people know they can reuse it."
+  basic_8:
     text: "You must <strong>publish open data under an open licence</strong> so that people can use it."
   standard_4:
     text: "You should provide <strong>machine-readable data in your rights statement about the licence</strong> for this data, so automatic tools can use it."
@@ -1304,7 +1313,7 @@ labels:
   exemplar_10:
     text: "You should <strong>guarantee that your data will be available in this form in the long-term</strong> so that people can decide how much to trust your data."
 # Technical Information Requirements
-  basic_10:
+  basic_9:
     text: "You must <strong>provide either a URL to your data or a URL to documentation</strong> about it so that people can find it."
   pilot_13:
     text: "You should <strong>have a URL that is a direct link to the data itself</strong> so that people can access it easily."
@@ -1314,9 +1323,9 @@ labels:
     text: "You should <strong>use a consistent pattern for different release URLs</strong> so that people can download each one automatically."
   standard_26:
     text: "You should <strong>have a document or feed with a list of available releases</strong> so people can create scripts to download them all."
-  basic_11:
+  basic_10:
     text: "You must <strong>provide access to releases of your data through a URL</strong> that gives the current version, a discoverable series of URLs or through a documentation page so that people can find it."
-  basic_12:
+  basic_11:
     text: "You must <strong>provide either an API endpoint URL or a URL to its documentation</strong> so that people can find it."
   standard_27:
     text: "You should <strong>have a service description document or single entry point for your API</strong> so that people can access it."


### PR DESCRIPTION
**For discussion, not ready for merge.**

Bit of background at http://lists.okfn.org/pipermail/okfn-discuss/2013-July/009455.html

This PR enables open data publishers who do not have clear rights to publish the data they are publishing to get an Open Data Certificate. The question **Do you have the rights to publish this data as open data?** now has four possible answers:
- yes, you have the rights to publish this data as open data
- no, you don't have the rights to publish this data as open data
- you're not sure if you have the rights to publish this data as open data
- the rights in this data are complicated or unclear

To get a **Raw** certificate, you must not answer 'no' to this question. You can get a **Raw** certificate if you answer that the rights are complicated or unclear.

To get a **Pilot** certificate, if you have answered that the rights are complicated or unclear then you must answer the question **Where do you detail the risks people might encounter if they use this data?** which has the help text:

> It can be risky for people to use data without a clear legal right to do so. Give a URL for a page that describes the risk of using this data.

To get a **Standard** certificate (or higher), you must answer that you have the rights to publish the data as open data. You cannot get a **Standard** certificate if your right to publish is complicated or unclear.

I'm interested in any thoughts about wording of these questions, particularly from @konklone and @CountCulture.
