### PR TITLE
Move status.csv controller method

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -16,15 +16,13 @@ class MainController < ApplicationController
 
     @head_commit = `git rev-parse HEAD`
 
-    respond_to do |format|
-      format.html { render '/home/status' }
-      format.csv {
-        csv = Rackspace.fetch_cache("statistics.csv")
-        render text: csv, content_type: "text/csv" 
-      }
-    end
+    render '/home/status'
   end
 
+  def status_csv
+    csv = Rackspace.fetch_cache("statistics.csv")
+    render text: csv, content_type: "text/csv"
+  end
 
   def status_response_sets
     @response_sets = ResponseSet.all.map do |m|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ OpenDataCertificate::Application.routes.draw do
   get 'clear_cache' => 'main#clear_cache', :via => :post
 
   # (public) stats about the application
+  get 'status.csv' => 'main#status_csv'
   get 'status' => 'main#status'
   get 'status/response_sets' => 'main#status_response_sets'
 


### PR DESCRIPTION
We've been getting a few notifications of out of memory errors when fetching the status CSV (https://theodi.airbrake.io/projects/89455/groups/68094930). I'm not sure if this would fix it, but we probably shouldn't be getting the git revision and all the other bits and bobs when downloading the status csv, so I've moved it to a different method.
