### PR TITLE
Bugfix certificate improvements

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -8,7 +8,7 @@ class MainController < ApplicationController
 
   def status
     @job_count = Delayed::Job.count
-    
+
     @counts = {
       'certificates' => Certificate.counts,
       'datasets'     => ResponseSet.counts

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -16,9 +16,9 @@ class ResponseSet < ActiveRecord::Base
 
   # there is already a protected method with this
   # has_many :dependencies, :through => :survey
-  
+
   class << self
-    
+
     def counts
       within_last_month = (Time.now - 1.month)..Time.now
       {
@@ -29,9 +29,9 @@ class ResponseSet < ActiveRecord::Base
         :published_datasets_this_month => self.published.select("DISTINCT(dataset_id)").where(created_at: within_last_month).count
       }
     end
-    
+
   end
-  
+
 
   def self.has_blank_value?(hash)
     return true if hash["answer_id"].kind_of?(Array) ? hash["answer_id"].all?{|id| id.blank?} : hash["answer_id"].blank?


### PR DESCRIPTION
This fixes the issue where anonymously created certificates can't access the improvements page.

**Please note:** This fix will also mean that all (new) response sets will have an associated dataset, which I think makes sense. This will affect the stats page which currently lists far fewer datasets than certificates.

Resolves #578
