### PR TITLE
downcase transfer target email to match devise

### DIFF
--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -2,6 +2,7 @@ class Transfer < ActiveRecord::Base
   include AASM
 
   attr_accessible :target_email, :dataset_id, :token_confirmation
+  before_save :downcase_target_email
 
   before_create :generate_token
   attr_readonly :token
@@ -43,6 +44,10 @@ class Transfer < ActiveRecord::Base
   end
 
   private
+
+  def downcase_target_email
+    self.target_email = self.target_email.downcase
+  end
 
   def generate_token
     self.token = SecureRandom::hex(32)

--- a/test/unit/transfer_test.rb
+++ b/test/unit/transfer_test.rb
@@ -22,4 +22,10 @@ class TransferTest < ActiveSupport::TestCase
 
     refute transfer.token.blank?
   end
+
+  test "target emails are downcased" do
+    transfer = FactoryGirl.create :transfer, target_email: "EMAIL.Address@example.com"
+
+    assert_equal 'email.address@example.com', transfer.target_email
+  end
 end


### PR DESCRIPTION
Did a quick test and devise downcases any signup emails.

This PR will downcase the target email for a transfer, so should match the address of the signed in user.

Thanks @LR-Technology-Group for providing more details on #616 - hopefully this will fix it.
