### PR TITLE
removed purge-questionnaire task

### DIFF
--- a/lib/tasks/odc.rake
+++ b/lib/tasks/odc.rake
@@ -73,17 +73,6 @@ end
 namespace :odc do
 
   desc "Task to run when a new version of the app has been deployed"
-  task :deploy => %w(surveyor:enqueue_surveys odc:purge_questionnaires cache:clear)
+  task :deploy => %w(surveyor:enqueue_surveys cache:clear)
 
-  desc "remove (12h) old and unclaimed questionnaires"
-  task :purge_questionnaires => :environment do
-
-    purge_before = Time.now - 12.hours
-
-    ResponseSet.
-      where(user_id: nil). # unclaimed response_sets
-      where(ResponseSet.arel_table[:updated_at].lt(purge_before)).
-      destroy_all
-
-  end
 end

--- a/test/unit/odc_rake_test.rb
+++ b/test/unit/odc_rake_test.rb
@@ -125,24 +125,6 @@ class OdcRakeTest < ActiveSupport::TestCase
   end
 
 
-  test "purge_questionnaires gets rid of unanswered questionnaires" do
-
-    yesterday =  Time.now - 24.hours
-
-    @a = FactoryGirl.create :response_set, user: nil
-    @b = FactoryGirl.create :response_set, updated_at: yesterday, user: nil
-    @c = FactoryGirl.create :response_set, updated_at: yesterday, user: FactoryGirl.create(:user)
-
-    assert_difference 'ResponseSet.count', -1 do
-      Rake::Task["odc:purge_questionnaires"].invoke
-    end
-
-    assert ResponseSet.exists? @a
-    assert_false ResponseSet.exists? @b
-    assert ResponseSet.exists? @c
-
-  end
-
   test "enqueue_surveys" do
     ENV['DIR'] = 'test/fixtures/surveys'
 


### PR DESCRIPTION
_only merge if you **don't** want the purge functionality_

There is a task to clear out the old unclaimed questionnaires (where someone has clicked 'create questionnaire', but hasn't signed up to claim it within the last 12 hours).

This task hasn't ever run on production,  though will do when the rake deploy tasks are fixed in #639.

This will change the counts on the [/status](https://certificates.theodi.org/status) page.  Currently they include certificates that haven't been claimed by a user.

If this is an important thing to keep track of - then _merge_ this PR to remove the purge task.  This needs to be done before #639 is resolved (cc/ @pezholio & @pikesley)
