### PR TITLE
Homepage globe cycle issue

### DIFF
--- a/app/assets/homepage_map/map.js
+++ b/app/assets/homepage_map/map.js
@@ -106,10 +106,12 @@ $(function(){
       };
 
       dropdown
-        .on('change', function(d){
-          setJurisdiction(this.options[this.selectedIndex].__data__);
+        .on('focus', function(){
           autoadvance = false;
           $autoadvance.fadeIn();
+        })
+        .on('change', function(d){
+          setJurisdiction(this.options[this.selectedIndex].__data__);
         })
         .selectAll('option')
         .data(countries).enter().append("option")


### PR DESCRIPTION
Previously the globe would only stop cycling when a new country was selected, which could be awkward on some browsers.

This stops the cycle when the select box is first selected.

resolves #652
