### PR TITLE
notify when deploy task starts/ends

### DIFF
--- a/lib/tasks/odc.rake
+++ b/lib/tasks/odc.rake
@@ -65,7 +65,13 @@ end
 namespace :odc do
 
   desc "Task to run when a new version of the app has been deployed"
-  task :deploy => %w(surveyor:enqueue_surveys odc:purge_questionnaires cache:clear)
+  task :deploy => %w(odc:deploy_start surveyor:enqueue_surveys odc:purge_questionnaires cache:clear) do
+    puts "odc:deploy task completed"
+  end
+
+  task :deploy_start do
+    puts "odc:deploy task started"
+  end
 
   desc "remove (12h) old and unclaimed questionnaires"
   task :purge_questionnaires => :environment do


### PR DESCRIPTION
Outputs `odc:deploy task started/completed` to the standard output when the rake task runs.

Already pushed to staging.
