### PR TITLE
remove airbrake Javascript Notifier

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,7 +8,6 @@
     %title ODI Open Data Certificate
     = favicon_link_tag       "favicon.ico"
     = stylesheet_link_tag    "application", :media => "all"
-    = begin airbrake_javascript_notifier rescue '' end
     = javascript_include_tag "application"
     = alternate_auto_discovery_link_tags
     = csrf_meta_tags


### PR DESCRIPTION
This removes the airbrake [Javascript Notifier](http://help.airbrake.io/kb/troubleshooting-2/javascript-notifier).
