### PR TITLE
guard against false kitten data

### DIFF
--- a/app/views/response_sets/_response_set.html.haml
+++ b/app/views/response_sets/_response_set.html.haml
@@ -1,5 +1,5 @@
 %div.certificate-data
-  - if response_set.kitten_data && !response_set.kitten_data.data[:description].empty?
+  - if response_set.kitten_data && response_set.kitten_data.data && !response_set.kitten_data.data[:description].empty?
     %hr.heavy
     %h3= t 'certificate.description'
     %p.description= response_set.kitten_data.data[:description]


### PR DESCRIPTION
resolves #763 

sometimes `kitten_data.data` [is false](https://github.com/theodi/open-data-certificate/blob/master/app/models/kitten_data.rb#L54)

This is causing errors when viewing the certificate, for example: https://certificates.theodi.org/datasets/1164/certificates/13292
