### PR TITLE
Ensure legacy redirect preserves format

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -43,7 +43,7 @@ class CertificatesController < ApplicationController
     elsif params[:type] == "embed"
       redirect_to embed_dataset_certificate_path certificate.response_set.dataset.id, certificate.id
     elsif params[:type] == "badge"
-      redirect_to badge_dataset_certificate_path certificate.response_set.dataset.id, certificate.id
+      redirect_to badge_dataset_certificate_path certificate.response_set.dataset.id, certificate.id, format: params[:format]
     end
   end
 

--- a/test/functional/certificates_controller_test.rb
+++ b/test/functional/certificates_controller_test.rb
@@ -36,6 +36,23 @@ class CertificatesControllerTest < ActionController::TestCase
     assert_equal "application/json", response.content_type
   end
 
+  test "Requesting legacy url performs a redirect" do
+    cert = FactoryGirl.create(:published_certificate_with_dataset)
+    cert.attained_level = "basic"
+    cert.save
+    get :legacy_show, {id: cert.id}
+    assert_redirected_to dataset_certificate_url dataset_id: cert.dataset.id, id: cert.id
+  end
+
+  test "Requesting legacy url for badge performs a redirect" do
+    cert = FactoryGirl.create(:published_certificate_with_dataset)
+    cert.attained_level = "basic"
+    cert.save
+    get :legacy_show, {id: cert.id, type: "badge", format: "png"}
+    
+    assert_redirected_to "http://test.host/datasets/1/certificates/2/badge.png"
+  end  
+  
   test "Requesting a JSON version of a certificate returns the correct level" do
     levels = {
         "basic" => "raw",


### PR DESCRIPTION
This is a small fix to the legacy redirect code that ensures that the format is preserved on a redirect.

This will simplify the OS fixing their links as they can add `.png` to the end of their current urls.
