### PR TITLE
Don't choke on blank rows

### DIFF
--- a/lib/extra/upload_usage_data.rb
+++ b/lib/extra/upload_usage_data.rb
@@ -18,6 +18,7 @@ module UploadUsageData
   end
 
   def self.create_csv(data)
+    data.reject! { |d| d.nil? }
     csv = CSV.generate(force_quotes: true, row_sep: "\r\n") do |csv|
       # Header row goes here
       headers = data.first.keys

--- a/test/unit/upload_usage_data_test.rb
+++ b/test/unit/upload_usage_data_test.rb
@@ -16,6 +16,14 @@ class UploadUsageDataTest < ActiveSupport::TestCase
     end
   end
 
+  test "create_csvs shouldn't choke on blank rows" do
+    data = [{foo: "foo", baz: "baz"}, nil, {foo: "baz", baz: "foo"}, nil]
+    csv = UploadUsageData.create_csv(data)
+
+    assert_equal 3, CSV.parse(csv).count
+    assert_true Csvlint::Validator.new( StringIO.new(csv) ).valid?
+  end
+
   test "find_collection finds the corrrect collection" do
     VCR.use_cassette('find_collection finds the corrrect collection') do
       collection = UploadUsageData.find_collection(ENV['GAPPS_CERTIFICATE_USAGE_COLLECTION'])


### PR DESCRIPTION
The all_certficates method sometimes generates blank rows. We don't want the csv gneerrator to choke on these.
