### PR TITLE
Only class published certificates as expired or expiring

### DIFF
--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -62,9 +62,9 @@ class ResponseSet < ActiveRecord::Base
   end
 
   def state
-    if certificate.expired?
+    if certificate.expired? && aasm_state == "published"
       "expired"
-    elsif certificate.expiring?
+    elsif certificate.expiring? && aasm_state == "published"
       "expiring"
     else
       aasm_state

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,11 @@ class User < ActiveRecord::Base
   end
 
   def has_expired_or_expiring_certificates?
-    response_sets.any? { |r| r.certificate.expired? || r.certificate.expiring? unless r.certificate.nil? }
+    response_sets.any? do |r|
+      unless r.certificate.nil? || r.aasm_state != "published"
+        r.certificate.expired? || r.certificate.expiring?
+      end
+    end
   end
 
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -20,7 +20,7 @@ class UserTest < ActiveSupport::TestCase
     user = FactoryGirl.create(:user)
 
     5.times do
-       FactoryGirl.create(:response_set_with_dataset, user: user)
+       FactoryGirl.create(:response_set_with_dataset, user: user, aasm_state: "published")
     end
 
     assert_equal false, user.has_expired_or_expiring_certificates?
@@ -30,7 +30,7 @@ class UserTest < ActiveSupport::TestCase
     user = FactoryGirl.create(:user)
 
     5.times do
-       FactoryGirl.create(:response_set_with_dataset, user: user)
+       FactoryGirl.create(:response_set_with_dataset, user: user, aasm_state: "published")
     end
 
     certificate = Certificate.last
@@ -44,7 +44,7 @@ class UserTest < ActiveSupport::TestCase
     user = FactoryGirl.create(:user)
 
     5.times do
-       FactoryGirl.create(:response_set_with_dataset, user: user)
+       FactoryGirl.create(:response_set_with_dataset, user: user, aasm_state: "published")
     end
 
     certificate = Certificate.last
@@ -52,6 +52,22 @@ class UserTest < ActiveSupport::TestCase
     certificate.save
 
     assert_equal true, user.has_expired_or_expiring_certificates?
+  end
+
+  test "has_expired_or_expiring_certificates? returns false if a user has an unpublished expiring certificate" do
+    user = FactoryGirl.create(:user)
+
+    5.times do
+       FactoryGirl.create(:response_set_with_dataset, user: user, aasm_state: "published")
+    end
+
+    FactoryGirl.create(:response_set_with_dataset, user: user, aasm_state: "draft")
+
+    certificate = Certificate.last
+    certificate.expires_at =  DateTime.now - 1.day
+    certificate.save
+
+    assert_equal false, user.has_expired_or_expiring_certificates?
   end
 
 end


### PR DESCRIPTION
Currently, draft certificates show up in the 'My Certificates' page as 'expired' or 'expiring'. Whilst this is true, it means users will always see warnings on their page, even though it may only be a draft certificate which is expired. We don't really want this to happen.
