### PR TITLE
Add context about automatically completed questions

### DIFF
--- a/app/views/surveyor/start.html.haml
+++ b/app/views/surveyor/start.html.haml
@@ -44,6 +44,11 @@
           .row-fluid
             .span8
               = f.url_field :documentation_url, class: 'string', placeholder: 'Documentation URL', value: @response_set.documentation_url
+              .lead
+                :markdown
+                  If your data is stored in a [CKAN](http://ckan.org/) repository (such as data.gov.uk), or marked up with
+                  [DCAT](http://www.w3.org/TR/vocab-dcat/), then we will attempt to automatically answer
+                  some of the questions for you in the next step. [Read more...](https://github.com/theodi/open-data-certificate/wiki/Marking-up-your-data-in-DCAT)
             .span4
               %button.btn.btn-large.btn-primary.submit{data:{toggle: 'popover', placement: 'bottom', content: 'Please wait while we check this URL'}}
                 %i.icon-loading.icon-spin.icon-refresh


### PR DESCRIPTION
As requested by a user, I've added a bit more context about what constitutes a dataset page that we can automatically complete from. I've also written up how to publish metadata in DCAT format [here](https://github.com/theodi/open-data-certificate/wiki/Marking-up-your-data-in-DCAT) and linked to that from the ODC page.

Here's what it looks like now:

![odi open data certificate 6](https://cloud.githubusercontent.com/assets/109774/3554924/aafe1960-0911-11e4-8507-20b4e27cd9bf.png)
