### PR TITLE
Check if people actually want to create a new response set last

### DIFF
--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -47,17 +47,16 @@ class SurveyorController < ApplicationController
         end
       end
 
-    elsif !@response_set.modifications_allowed?
-      # they *actually* want to create a new response set
-      attrs = prepare_new_response_set
-      create_new_response_set(attrs)
-
     elsif @response_set.survey.superceded?
       latest_survey = Survey.newest_survey_for_access_code(params[:survey_code])
       unless latest_survey.nil?
         attrs = prepare_new_response_set
         switch_survey(attrs, latest_survey)
       end
+    elsif !@response_set.modifications_allowed?
+      # they *actually* want to create a new response set
+      attrs = prepare_new_response_set
+      create_new_response_set(attrs)
     end
 
     if params[:update]


### PR DESCRIPTION
Needed for https://github.com/theodi/shared/issues/277

We should check if people are just editing their questionniare as the very last thing. Sometimes, it just creates a new response set at the same state instead of updating the survey.
