### PR TITLE
Add Error Message and Timeout to initial survey page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -245,6 +245,7 @@ $(document).ready(function($){
 
   $('.survey-intro .submit').click(function() {
     $(this).addClass('disabled');
+    $(this).removeClass('error');
     $(this).popover('show');
     var form = $(this.form);
     $.ajax({
@@ -254,7 +255,14 @@ $(document).ready(function($){
       data: form.serialize(),
       success: function(data) {
         window.location.replace(data.survey_path)
-      }
+      },
+      error: function() {
+        $('.survey-intro .submit').removeClass('disabled')
+        $('.survey-intro .submit').addClass('error')
+        var popover = $('.survey-intro .submit').data('popover')
+        popover.options.content = "Sorry, an error occurred. Please try again."
+        popover.show()
+      },
       timeout: 120000
     })
     return false;

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -1801,13 +1801,17 @@ header .save-button {
   }
 
   form .btn-large {
-    i.icon-loading {
+    i.icon-loading, i.icon-exclamation-sign {
       display: none;
       margin-right: 3px;
     }
 
     &.disabled {
       i.icon-loading { display: inline-block; }
+    }
+
+    &.error {
+      i.icon-exclamation-sign { display: inline-block; }
     }
   }
 

--- a/app/views/surveyor/start.html.haml
+++ b/app/views/surveyor/start.html.haml
@@ -52,6 +52,7 @@
             .span4
               %button.btn.btn-large.btn-primary.submit{data:{toggle: 'popover', placement: 'bottom', content: 'Please wait while we check this URL'}}
                 %i.icon-loading.icon-spin.icon-refresh
+                %i.icon-exclamation-sign
                 Check URL
 
           %p


### PR DESCRIPTION
I've been trying to fix https://github.com/theodi/shared/issues/301, but I rarely get any issues with it. I've therefore added a specific timeout of two minutes to the initial survey page. If the timeout is reached, or another error occurs, the user is asked to try again. This is very much an edge case, but stops the survey from appearing like it's never progressing.
