### PR TITLE
Strip HTML tags from description

### DIFF
--- a/app/views/response_sets/_response_set.html.haml
+++ b/app/views/response_sets/_response_set.html.haml
@@ -2,7 +2,7 @@
   - if response_set.kitten_data && response_set.kitten_data.data && !response_set.kitten_data.data[:description].empty?
     %hr.heavy
     %h3= t 'certificate.description'
-    %p.description= response_set.kitten_data.data[:description]
+    %p.description= strip_tags response_set.kitten_data.data[:description]
 
   - response_set.survey.sections.each do |section|
     - questions = section.questions_for_certificate response_set

--- a/app/views/shared/_response_set_description.html.haml
+++ b/app/views/shared/_response_set_description.html.haml
@@ -6,4 +6,4 @@
     %hr.heavy
 
   %h3 Description
-  %p= description
+  %p= strip_tags description


### PR DESCRIPTION
Sometimes there may be HTML in dataset descriptions (for example: if they're pulled from Data Kitten). At the moment, they show sanitised, so you can see all the HTML markup, so we want to strip 'em out.
