### PR TITLE
Use rails 4.0.2 default for enforce_available_locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,10 @@ module OpenDataCertificate
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    # This setting is being defaulted to true in rails 4.0.2 onwards
+    # This removes a deprecation warning
+    config.i18n.enforce_available_locales = true
+
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"
 

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -5,8 +5,8 @@ class ApplicationHelperTest < ActionView::TestCase
     I18n.locale = :en
     called = false
 
-    scope_locale :pirate do
-      assert_equal :pirate, I18n.locale
+    scope_locale :fr do
+      assert_equal :fr, I18n.locale
       called = true
     end
 


### PR DESCRIPTION
This silences a deprecation warning in the logs & test output
