### PR TITLE
Show certificates as automatically awarded when generated via the api

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,7 @@ en:
     description: Description
     certification_types:
       self: self certified
+      auto: automatically awarded
       community: community certified
       odi_audited: ODI audited
     mark_audited: Mark audited

--- a/test/factories/response_set_factory.rb
+++ b/test/factories/response_set_factory.rb
@@ -37,6 +37,10 @@ FactoryGirl.define do
     r.string_value {}
     r.response_other {}
     r.response_group {}
+
+    factory :valid_response do |r|
+      question
+      answer
+    end
   end
-  
 end

--- a/test/unit/certificate_test.rb
+++ b/test/unit/certificate_test.rb
@@ -65,6 +65,24 @@ class CertificateTest < ActiveSupport::TestCase
 
   end
 
+  test 'certification_type if auto generated' do
+    response_set = FactoryGirl.create(:response_set_with_dataset)
+    3.times { FactoryGirl.create(:valid_response, response_set: response_set) }
+    certificate_generator = CertificateGenerator.create(response_set: response_set)
+    certificate = response_set.certificate
+
+    assert_equal :auto, certificate.certification_type
+  end
+
+  test 'no longer auto generated if responses have been updated since generation' do
+    response_set = FactoryGirl.create(:response_set_with_dataset, updated_at: 4.minutes.ago)
+    3.times { FactoryGirl.create(:valid_response, response_set: response_set, updated_at: 6.minutes.ago) }
+    certificate_generator = CertificateGenerator.create(response_set: response_set, updated_at: 5.minutes.ago)
+    certificate = response_set.certificate
+
+    assert_equal :self, certificate.certification_type
+  end
+
   test 'published_certificates' do
     @certificate1.update_attributes(published: true)
     @certificate2.update_attributes(published: true)


### PR DESCRIPTION
If a certificate is created by an api call then it defaults to `automatically awarded` it will become `self certified` new responses are added via the web interface as we assume a human has looked at it then.
