### PR TITLE
Stop publisher changed warning showing up all the time

### DIFF
--- a/app/views/response_sets/_response_set.html.haml
+++ b/app/views/response_sets/_response_set.html.haml
@@ -15,7 +15,7 @@
           - response_text = response.statement_text
           - answer = response_set.autocomplete_override_message_for(response.question)
           - if response_text != ''
-            - explanation_required = (response.autocompletable? && !response.all_autocompleted(@responses)) || response.error
+            - explanation_required = (response.autocompletable? && !response.all_autocompleted(responses)) || response.error
 
             - state = 'error' if explanation_required
             - state = 'warning' if explanation_required && answer.message?


### PR DESCRIPTION
By limiting it to only check for changes in the section of the response. I'm still not sure the logic for this is correct or even makes sense though.
