### PR TITLE
Include dataset url in duplicate response

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -133,10 +133,10 @@ class DatasetsController < ApplicationController
         campaign = CertificationCampaign.where(:user_id => current_user.id).find_or_create_by_name(campaign)
       end
       if dataset
-        if Dataset.where(documentation_url: dataset[:documentationUrl]).exists?
+        if existing_dataset = Dataset.where(documentation_url: dataset[:documentationUrl]).first
           campaign.increment!(:duplicate_count) if campaign
 
-          {success: false, errors: ['Dataset already exists']}
+          {success: false, errors: ['Dataset already exists'], dataset_id: existing_dataset.id, dataset_url: existing_dataset.api_url}
         else
           generator = CertificateGenerator.create(request: dataset, user: current_user, certification_campaign: campaign)
           generator.delay.generate(jurisdiction, create_user)

--- a/test/functional/datasets_controller_test.rb
+++ b/test/functional/datasets_controller_test.rb
@@ -312,6 +312,8 @@ class DatasetsControllerTest < ActionController::TestCase
     body = JSON.parse(response.body)
     assert_equal(422, response.status)
     assert_equal(false, body['success'])
+    assert_equal(dataset.id, body['dataset_id'])
+    assert_equal(dataset_url(dataset, :format => :json), body['dataset_url'])
     assert_equal(["Dataset already exists"], body['errors'])
   end
 


### PR DESCRIPTION
When the api denies creating a duplicate dataset & certificate include the results url in the payload so that CertificateFactory can ask about the existing dataset.
