### PR TITLE
Report published datasets with certificates

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -6,6 +6,16 @@ class DatasetsController < ApplicationController
   before_filter :authenticate_user_from_token!, only: [:create, :update_certificate, :import_status]
   before_filter(:only => [:show, :index]) { alternate_formats [:feed, :json] }
 
+  def info
+    respond_to do |format|
+      format.json do
+        render json: {
+          published_certificate_count: Dataset.published_count
+        }
+      end
+    end
+  end
+
   def index
 
     @datasets = Dataset

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -34,6 +34,10 @@ class Dataset < ActiveRecord::Base
     end
   end
 
+  def self.published_count
+    Dataset.joins(:certificates).merge(Certificate.published).count(:distinct => 'datasets.id')
+  end
+
   def title
     read_attribute(:title) || set_default_title!(response_sets.first.try(:dataset_title_determined_from_responses)) || response_sets.first.try(:title) || ResponseSet::DEFAULT_TITLE
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ OpenDataCertificate::Application.routes.draw do
     get :typeahead, on: :collection
     get :admin, on: :collection
     get :schema, on: :collection
+    get :info, on: :collection
 
     collection do
       get 'status/:certificate_generator_id', to: 'datasets#import_status', as: 'status'

--- a/test/functional/datasets_controller_test.rb
+++ b/test/functional/datasets_controller_test.rb
@@ -402,4 +402,27 @@ class DatasetsControllerTest < ActionController::TestCase
     get :import_status, certificate_generator_id: generator.id
     assert_response 403
   end
+
+  test "dataset info endpoint with no data" do
+    get :info, format: :json
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_equal(0, body['published_certificate_count'])
+  end
+
+  test "dataset info with draft datasets" do
+    3.times { FactoryGirl.create(:dataset) }
+    get :info, format: :json
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_equal(0, body['published_certificate_count'])
+  end
+
+  test "dataset info with published datasets" do
+    3.times { FactoryGirl.create(:published_certificate_with_dataset) }
+    get :info, format: :json
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_equal(3, body['published_certificate_count'])
+  end
 end


### PR DESCRIPTION
So that the dashboard has a correct number that can be fetched from structured data.
