### PR TITLE
Promote the Mexico questionnaire to beta

### DIFF
--- a/surveys/odc_questionnaire.MX.rb
+++ b/surveys/odc_questionnaire.MX.rb
@@ -1,7 +1,7 @@
 survey 'MX',
   :full_title => 'Mexico',
   :default_mandatory => 'false',
-  :status => 'alpha',
+  :status => 'beta',
   :description => '<p>El presente cuestionario de autoevaluación genera un certificado e insignia de datos abiertos que usted puede publicar para informar al público sobre estos datos abiertos. Nosotros utilizaremos sus respuestas para determinar la manera en que las organizaciones publican los datos abiertos.</p><p>El responder estas preguntas, demuestra el esfuerzo hecho para cumplir con la legislación relativa a datos abiertos. Adicionalmente, sugerimos revise la legislación aplicable específicamente a su sector.</p><p>No es necesario reponder todas las preguntas para obtener el certificado. Responda solamente las que pueda.</p>' do
 
   translations :en => :default


### PR DESCRIPTION
This updates the survey description.

Once deployed the surveyor rake task to import it needs to be run:
`rake surveyor:build_changed_survey FILE=surveys/odc_questionnaire.MX.rb`

This will fix #947 
