### PR TITLE
Report problematic certificates

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -108,6 +108,13 @@ class CertificatesController < ApplicationController
     redirect_to dataset_certificate_path params.select {|d| [:dataset_id, :id].include? d}
   end
 
+  def report
+    @certificate.report!(params[:reasons], params[:email])
+
+    flash[:notice] = I18n.t('certificates.flashes.reported')
+    redirect_to dataset_certificate_path(params[:dataset_id], @certificate)
+  end
+
   # used by an admin to mark as audited
   def update
     authorize! :manage, @certificate

--- a/app/mailers/certificate_mailer.rb
+++ b/app/mailers/certificate_mailer.rb
@@ -1,0 +1,12 @@
+class CertificateMailer < ActionMailer::Base
+
+  default from: Devise.mailer_sender
+
+  def report(certificate, reason, reporter)
+    @certificate = certificate
+    @reason = reason
+    from = reporter.presence || Devise.mailer_sender
+    mail(subject: "Reported certificate: #{certificate.name}", to: Devise.mailer_sender, from: from)
+  end
+  
+end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -221,4 +221,9 @@ class Certificate < ActiveRecord::Base
     Rails.application.routes.url_helpers.dataset_certificate_url(self.dataset, self, host: OpenDataCertificate.hostname)
   end
 
+  def report!(reason, reporter)
+    CertificateMailer.report(self, reason, reporter).deliver
+  end
+  handle_asynchronously :report!
+
 end

--- a/app/views/certificate_mailer/report.text.erb
+++ b/app/views/certificate_mailer/report.text.erb
@@ -1,0 +1,10 @@
+<%= @certificate.name %>
+<%= "-" * [@certificate.name.size, 80].min %>
+
+This certificate has been reported as having a problem:
+
+<%= @reason %>
+
+<%= "-" * [@certificate.name.size, 80].min %>
+
+<%= @certificate.url %>

--- a/app/views/certificates/_community_verification_panel.html.haml
+++ b/app/views/certificates/_community_verification_panel.html.haml
@@ -28,3 +28,10 @@
     - @certificate.verifying_users.each do |user|
       %li
         = user.identifier
+
+%p
+  =link_to t('certificate.report.link'), "#report-#{@certificate.id}", :'data-toggle' => :modal
+  =t 'certificate.report.text'
+
+- content_for :modal_content do
+  =render :partial => 'report', :locals => {:certificate => @certificate}

--- a/app/views/certificates/_report.html.haml
+++ b/app/views/certificates/_report.html.haml
@@ -1,0 +1,15 @@
+.modal.modal-wide.hide.fade.report-certificate{:id => "report-#{certificate.id}"}
+  .modal-header
+    %button.close{:type => :button, 'data-dismiss' => :modal, 'aria-hidden' => true} &times;
+    %h3
+      .icon-cog
+      =t ".heading"
+  .modal-body
+    %p=t ".intro", :name => certificate.name
+    = form_tag report_dataset_certificate_path do |f|
+      %p
+        = text_area_tag :reasons, nil, :rows => 5, :placeholder => t('.describe_the_problem'), :class => 'input-xxlarge'
+      %p
+        = label_tag :email, t('.contact_email')
+        = text_field_tag :email, current_user.try(:email), :class => 'input-large'
+      = submit_tag t(".report"), class: 'btn btn-primary', :name => nil

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,6 +213,16 @@ en:
       certifiers: "This certificate has been verified by **%{count}**:"
       person: person
 
+    report:
+      heading: Report a problem with this certificate
+      intro: "Please describe the problem you've found with the certificate for '%{name}'"
+      report: "Report certifcate"
+      contact_email: Contact email
+      describe_the_problem: Describe the problem
+
+    flashes:
+      reported: 'This certificate has been reported to The ODI'
+
   certificate:
     on_date: "on %{date}"
     this_data_has_achieved: This data has achieved
@@ -238,6 +248,9 @@ en:
     expired_notice: "This certificate should be updated to reflect the latest questionnaire for %{jurisdiction}."
     expiring_notice: "This certificate will expire in %{days} days. Update to reflect the latest questionnaire for %{jurisdiction}."
     claim_this_certificate: "Is this your dataset?"
+    report:
+      link: Report a problem
+      text: with this certificate
 
   datasets:
     datasets: Datasets

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ OpenDataCertificate::Application.routes.draw do
          get 'embed', to: 'certificates#embed', as: 'embed'
          get 'badge', to: 'certificates#badge', as: 'badge'
          post 'verify'
+         post :report
        end
     end
   end

--- a/test/functional/certificates_controller_test.rb
+++ b/test/functional/certificates_controller_test.rb
@@ -209,4 +209,12 @@ class CertificatesControllerTest < ActionController::TestCase
     end
   end
 
+  test "reporting certificate sends an email" do
+    certificate = FactoryGirl.create(:published_certificate_with_dataset)
+    post :report, dataset_id: certificate.dataset.id, id: certificate.id
+    assert_difference 'ActionMailer::Base.deliveries.size', 1 do
+      Delayed::Worker.new.work_off 1
+    end
+  end
+
 end


### PR DESCRIPTION
send an email to certificate@theodi.org with their reasons for reporting it and a contact email.
