### PR TITLE
Increase size of `KittenData#data` field to `MEDIUMTEXT`

### DIFF
--- a/db/migrate/20141117145346_expand_kitten_data_field.rb
+++ b/db/migrate/20141117145346_expand_kitten_data_field.rb
@@ -1,0 +1,6 @@
+class ExpandKittenDataField < ActiveRecord::Migration
+  def change
+    # 16.megabytes - 1 should trigger a column type of MEDIUMTEXT on MySQL
+    change_column :kitten_data, :data, :text, :limit => 16.megabytes - 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20141022100044) do
+ActiveRecord::Schema.define(:version => 20141117145346) do
 
   create_table "answers", :force => true do |t|
     t.integer  "question_id"
@@ -179,10 +179,10 @@ ActiveRecord::Schema.define(:version => 20141022100044) do
   end
 
   create_table "kitten_data", :force => true do |t|
-    t.text     "data"
+    t.text     "data",            :limit => 16777215
     t.integer  "response_set_id"
-    t.datetime "created_at",      :null => false
-    t.datetime "updated_at",      :null => false
+    t.datetime "created_at",                          :null => false
+    t.datetime "updated_at",                          :null => false
     t.string   "url"
   end
 


### PR DESCRIPTION
Which is a size limit of 16MB instead of 64KB as the `:distributions` field in datasets is only going to get bigger over time
