### PR TITLE
Stop double acceptance of a transfer

### DIFF
--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -20,6 +20,9 @@ class TransfersController < ApplicationController
 
   def claim
     @transfer = Transfer.find params[:id]
+    if @transfer.accepted?
+      redirect_to dataset_path(@transfer.dataset)
+    end
     session[:sign_in_redirect] = request.original_fullpath unless user_signed_in? 
   end
 

--- a/app/views/datasets/show.html.haml
+++ b/app/views/datasets/show.html.haml
@@ -15,7 +15,10 @@
 
 
 %hr.heavy
-= render partial: 'dataset_min', object: @dataset, locals: {expanded: true}
+- if can? :manage, @dataset
+  = render partial: 'dataset', object: @dataset, locals: {expanded: true}
+- else
+  = render partial: 'dataset_min', object: @dataset, locals: {expanded: true}
 
 - content_for :rss_feed do
   = dataset_path(@dataset, format: 'feed')

--- a/test/functional/transfers_controller_test.rb
+++ b/test/functional/transfers_controller_test.rb
@@ -111,4 +111,12 @@ class TransfersControllerTest < ActionController::TestCase
     assert_equal I18n.t('transfers.flashes.access_denied'), flash[:error]
   end
 
+  test "accepting a certificate the user already own's redirects to dataset" do
+    transfer = FactoryGirl.create(:transfer, :aasm_state => :accepted)
+    assert transfer.accepted?
+    sign_in transfer.user
+    get :claim, id: transfer.id, token: transfer.token
+    assert_redirected_to dataset_path(transfer.dataset)
+  end
+
 end


### PR DESCRIPTION
If transfer is accepted redirect to dataset page

The dataset page shows you the details of certificates if you can manage them, otherwise just the published information.

Fixes #892 
