### PR TITLE
Stop erroring on missing response_set

### DIFF
--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -199,7 +199,8 @@ class SurveyorController < ApplicationController
   private
   def set_response_set_and_render_context
     super
-    authorize!(:edit, @response_set) if @response_set
+    raise ActiveRecord::RecordNotFound unless @response_set.present?
+    authorize!(:edit, @response_set)
   end
 
   def prepare_new_response_set

--- a/test/functional/surveyor_controller_test.rb
+++ b/test/functional/surveyor_controller_test.rb
@@ -122,6 +122,16 @@ class SurveyorControllerTest < ActionController::TestCase
     assert_response 200
   end
 
+  test "404s if response_set does not exist" do
+    FactoryGirl.create(:survey, access_code: 'gb')
+
+    get :edit, use_route: :surveyor,
+      survey_code: "gb",
+      response_set: "nope"
+
+    assert_response :not_found
+  end
+
   test "repeater field fragment" do
     question = FactoryGirl.create(:question, question_group: FactoryGirl.create(:question_group, display_type: 'repeater'))
     survey = question.survey_section.survey


### PR DESCRIPTION
Most likely caused by people returning to surveys that have been purged. This at least gives them a link to start a new survey.
