### PR TITLE
Restore missing documentation urls.

### DIFF
--- a/db/migrate/20141202154424_restore_documentation_urls.rb
+++ b/db/migrate/20141202154424_restore_documentation_urls.rb
@@ -1,0 +1,15 @@
+class RestoreDocumentationUrls < ActiveRecord::Migration
+  def up
+    update(<<-SQL)
+      update datasets d
+      join response_sets rs on (rs.dataset_id = d.id and rs.aasm_state = 'published')
+      right outer join responses r on (rs.id=r.response_set_id)
+      join questions q on (r.question_id = q.id and q.`reference_identifier` = 'documentationUrl')
+      set d.documentation_url = r.string_value
+      where documentation_url not like 'http%' and r.string_value like 'http%';
+    SQL
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20141127164041) do
+ActiveRecord::Schema.define(:version => 20141202154424) do
 
   create_table "answers", :force => true do |t|
     t.integer  "question_id"


### PR DESCRIPTION
They were lost due to a copy past error that was fixed in 63c1a1e558
