### PR TITLE
404 instead of error for a non-existent route

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -16,12 +16,15 @@ class CertificatesController < ApplicationController
 
   def legacy_show
     certificate = Certificate.find params[:id]
-    if params[:type].nil?
+    case params[:type]
+    when nil
       redirect_to dataset_certificate_path certificate.response_set.dataset.id, certificate.id
-    elsif params[:type] == "embed"
+    when "embed"
       redirect_to embed_dataset_certificate_path certificate.response_set.dataset.id, certificate.id
-    elsif params[:type] == "badge"
+    when "badge"
       redirect_to badge_dataset_certificate_path certificate.response_set.dataset.id, certificate.id, format: params[:format]
+    else
+      raise ActiveRecord::RecordNotFound
     end
   end
 

--- a/test/functional/certificates_controller_test.rb
+++ b/test/functional/certificates_controller_test.rb
@@ -53,6 +53,26 @@ class CertificatesControllerTest < ActionController::TestCase
     assert_redirected_to "http://test.host/datasets/1/certificates/1/badge.png"
   end
 
+  test "Requesting legacy url for embed performs a redirect" do
+    cert = FactoryGirl.create(:published_certificate_with_dataset)
+    cert.attained_level = "basic"
+    cert.save
+    get :legacy_show, {id: cert.id, type: "embed"}
+
+    assert_redirected_to "http://test.host/datasets/1/certificates/1/embed"
+  end
+
+  test "requesting a legacy url with another type returns a not found" do
+    # Some spiders are mistaking arguments to juvia as urls to fetch
+
+    cert = FactoryGirl.create(:published_certificate_with_dataset)
+    cert.attained_level = "basic"
+    cert.save
+    get :legacy_show, {id: cert.id, type: "random"}
+
+    assert_response :not_found
+  end
+
   test "Requesting a JSON version of a certificate returns the correct level" do
     levels = {
         "basic" => "raw",


### PR DESCRIPTION
A spider has decided that an argument to juvia for comments is a URL
it should request.

https://theodi.airbrake.io/projects/89455/groups/1304552616114976042

This will hopefully tell the spider to go away and not fill up the error logs unnecessarily.