### PR TITLE
Return a 404 for badges if there is no published certificate

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -3,11 +3,10 @@ class CertificatesController < ApplicationController
 
   before_filter(:except => [:legacy_show, :certificate_from_dataset_url]) { get_certificate }
   before_filter(:only => [:show]) { alternate_formats [:json] }
+  before_filter(:only => [:show, :badge]) { readable? }
   before_filter(:only => [:badge]) { log_embed }
 
   def show
-    raise ActiveRecord::RecordNotFound if cannot?(:read, @certificate)
-
     respond_to do |format|
       format.html
       format.json
@@ -58,7 +57,6 @@ class CertificatesController < ApplicationController
   end
 
   def badge
-    raise ActiveRecord::RecordNotFound unless @certificate
     respond_to do |format|
       format.js
       format.html { render 'badge', :layout => false }
@@ -120,6 +118,10 @@ class CertificatesController < ApplicationController
 
     def get_dataset
       @dataset = Dataset.find(params[:dataset_id])
+    end
+
+    def readable?
+      raise ActiveRecord::RecordNotFound unless @certificate && can?(:read, @certificate)
     end
 
     def log_embed

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -58,6 +58,7 @@ class CertificatesController < ApplicationController
   end
 
   def badge
+    raise ActiveRecord::RecordNotFound unless @certificate
     respond_to do |format|
       format.js
       format.html { render 'badge', :layout => false }
@@ -111,15 +112,19 @@ class CertificatesController < ApplicationController
 
     def get_certificate
       if params[:id]
-        @certificate = Dataset.find(params[:dataset_id]).certificates.find(params[:id])
+        @certificate = get_dataset.certificates.find(params[:id])
       else
-        @certificate = Dataset.find(params[:dataset_id]).certificate
+        @certificate = get_dataset.certificate
       end
+    end
+
+    def get_dataset
+      @dataset = Dataset.find(params[:dataset_id])
     end
 
     def log_embed
       unless request.referer =~ /https?:\/\/#{request.host_with_port}./
-        @certificate.dataset.register_embed(request.referer)
+        get_dataset.register_embed(request.referer)
       end
     end
 

--- a/test/functional/certificates_controller_test.rb
+++ b/test/functional/certificates_controller_test.rb
@@ -273,4 +273,10 @@ class CertificatesControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
+  test "badge returns not found if certificate is draft" do
+    cert = FactoryGirl.create(:certificate_with_dataset)
+    get :badge, {dataset_id: cert.dataset.id}
+    assert_response 404
+  end
+
 end

--- a/test/functional/certificates_controller_test.rb
+++ b/test/functional/certificates_controller_test.rb
@@ -204,6 +204,16 @@ class CertificatesControllerTest < ActionController::TestCase
     end
   end
 
+  test "creates an embed stat when default badge is embeded" do
+    @request.env['HTTP_REFERER'] = 'http://example.com'
+
+    cert = FactoryGirl.create(:published_certificate_with_dataset)
+
+    assert_difference ->{cert.dataset.embed_stats.count}, 1 do
+      get :badge, {dataset_id: cert.dataset.id}
+    end
+  end
+
   test "doesn't create a stat when there is no referrer" do
     @request.env['HTTP_REFERER'] = nil
 
@@ -211,6 +221,22 @@ class CertificatesControllerTest < ActionController::TestCase
 
     assert_no_difference ->{cert.dataset.embed_stats.count} do
       get :badge, {dataset_id: cert.dataset.id, id: cert.id}
+    end
+    assert_no_difference ->{cert.dataset.embed_stats.count} do
+      get :badge, {dataset_id: cert.dataset.id}
+    end
+  end
+
+  test "doesn't create a stat when unpublished" do
+    @request.env['HTTP_REFERER'] = 'http://example.com'
+
+    cert = FactoryGirl.create(:certificate_with_dataset)
+
+    assert_no_difference ->{cert.dataset.embed_stats.count} do
+      get :badge, {dataset_id: cert.dataset.id, id: cert.id}
+    end
+    assert_no_difference ->{cert.dataset.embed_stats.count} do
+      get :badge, {dataset_id: cert.dataset.id}
     end
   end
 
@@ -221,6 +247,9 @@ class CertificatesControllerTest < ActionController::TestCase
 
     assert_no_difference ->{cert.dataset.embed_stats.count} do
       get :badge, {dataset_id: cert.dataset.id, id: cert.id}
+    end
+    assert_no_difference ->{cert.dataset.embed_stats.count} do
+      get :badge, {dataset_id: cert.dataset.id}
     end
   end
 


### PR DESCRIPTION
The log_referer task tries to use the certificate to find the dataset before it's been decided if this should be logged