### PR TITLE
Expect user entered addresses to fail

### DIFF
--- a/lib/odibot.rb
+++ b/lib/odibot.rb
@@ -15,7 +15,7 @@ class ODIBot
       Rails.cache.write(@url, code, expires_in: 5.minute)
     end
     code
-  rescue SocketError
+  rescue SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError, Timeout::Error
     0
   end
 

--- a/test/unit/odibot_test.rb
+++ b/test/unit/odibot_test.rb
@@ -75,4 +75,11 @@ class ODIBotTest < ActiveSupport::TestCase
     refute ODIBot.new("foo bar").valid?
   end
 
+  [SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError, Timeout::Error].each do |error|
+    test "handles #{error.name}" do
+      stub_request(:get, "http://www.example.com").to_raise(error)
+      refute ODIBot.new("http://www.example.com").valid?
+    end
+  end
+
 end


### PR DESCRIPTION
Connecting to a website provided by a user can fail for all sorts of reasons.

Now handling:
  - Generic socket errors
  - Connection refused
  - Connection reset
  - Host unreachable
  - SSL failure
  - Timeouts