### PR TITLE
Handle refreshes on certificate form url

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@ OpenDataCertificate::Application.routes.draw do
 
   mount Surveyor::Engine => "/surveys", :as => "surveyor"
   Surveyor::Engine.routes.draw do
-    match '/:survey_code/:response_set_code/requirements', :to => 'surveyor#requirements', :as => 'view_my_survey_requirements', :via => :get
-    match '/:survey_code/:response_set_code/continue', :to => 'surveyor#continue', :as => 'continue_my_survey', :via => :get
-    match '/:survey_code/:response_set_code/repeater_field/:question_id/:response_index/:response_group', :to => 'surveyor#repeater_field', :as => 'repeater_field', :via => :get
+    get '/:survey_code/:response_set_code/requirements', :to => 'surveyor#requirements', :as => 'view_my_survey_requirements'
+    get '/:survey_code/:response_set_code/continue', :to => 'surveyor#continue', :as => 'continue_my_survey'
+    get '/:survey_code/:response_set_code/repeater_field/:question_id/:response_index/:response_group', :to => 'surveyor#repeater_field', :as => 'repeater_field'
     get '/:survey_code/:response_set_code/save_and_finish', :to => 'surveyor#force_save_questionnaire', :as => 'force_save_questionnaire'
 
     get  '/:survey_code/:response_set_code/start', :to => 'surveyor#start', as: 'start'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ OpenDataCertificate::Application.routes.draw do
     get '/:survey_code/:response_set_code/save_and_finish', :to => 'surveyor#force_save_questionnaire', :as => 'force_save_questionnaire'
 
     get  '/:survey_code/:response_set_code/start', :to => 'surveyor#start', as: 'start'
+    get '/:survey_code/:response_set_code', :to => redirect('/surveys/%{survey_code}/%{response_set_code}/take', status: 302)
 
     resources :jurisdictions, :only => :index
 


### PR DESCRIPTION
Currently if you refresh the survey page you'll get errors, this redirects requests to the correct url.