### PR TITLE
Fixed typo in jurisdiction GET parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Certificates can be created and updated using the JSON API.
 The API methods are:
 
 - GET `/jurisdictions` - This method provides a list of the available jurisdictions and associated information
-- GET `/datasets/schema` - This method provides the list of questions, their types and possible choices. You must specify your jurisdiction by title with the `jursidiction` GET parameter
+- GET `/datasets/schema` - This method provides the list of questions, their types and possible choices. You must specify your jurisdiction by title with the `jurisdiction` GET parameter
 - POST `/datasets` - This method allows you to create a new dataset, it will be automatically published if valid
 - POST `/datasets/:id/certificates` - This method allows you to update a dataset, it will be automatically published if valid
 


### PR DESCRIPTION
Corrected a small mistake on the GET parameter description in the README that may cause trouble for non-suspecting users, like myself.