### PR TITLE
Extra user account details

### DIFF
--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -3796,3 +3796,8 @@ body{
     }
   }
 }
+
+// Rails thinks it knows best but it doesn't
+.check_box .field_with_errors {
+  display: inline;
+}

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -779,6 +779,8 @@ hr.heavy {
 
       a {
         color: #fff;
+      }
+      > a {
         padding: 20px;
       }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ActiveRecord::Base
 
   before_save :ensure_authentication_token
 
+  validates :agreed_to_terms, acceptance: {accept: true}, allow_nil: true 
+
   def ensure_authentication_token
     if authentication_token.blank?
       self.authentication_token = generate_authentication_token
@@ -27,34 +29,6 @@ class User < ActiveRecord::Base
 
   def after_password_reset
     confirm!
-  end
-
-  # Coped from https://github.com/plataformatec/devise/blob/v3.0.3/lib/devise/models/database_authenticatable.rb
-  # Sorry but I couldn't add a check around this method as .valid? wipes
-  # other errors from the hash
-  def update_with_password(params, *options)
-    current_password = params.delete(:current_password)
-
-    if params[:password].blank?
-      params.delete(:password)
-      params.delete(:password_confirmation) if params[:password_confirmation].blank?
-    end
-
-    # special case for rails handling of boolean check_box
-    agreed_to_terms = params[:agreed_to_terms] == "1"
-
-    result = if valid_password?(current_password) && agreed_to_terms
-      update_attributes(params, *options)
-    else
-      self.assign_attributes(params, *options)
-      self.valid?
-      self.errors.add(:current_password, current_password.blank? ? :blank : :invalid) unless valid_password?(current_password)
-      self.errors.add(:agreed_to_terms, :blank) unless agreed_to_terms?
-      false
-    end
-
-    clean_up_passwords
-    result
   end
 
   def to_s

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ActiveRecord::Base
   has_many :sent_claims, class_name: 'Claim', foreign_key: 'initiating_user_id'
   has_many :received_claims, class_name: 'Claim', foreign_key: 'user_id'
 
-  attr_accessible :name, :short_name, :email, :password, :password_confirmation, :default_jurisdiction
+  attr_accessible :name, :short_name, :email, :password, :password_confirmation, :default_jurisdiction, :organization, :agreed_to_terms
 
   before_save :ensure_authentication_token
 

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -13,5 +13,9 @@
   .form-field
     = f.label :password_confirmation
     = f.password_field :password_confirmation, :class => 'span8'
+  .form-field
+    = f.label :agreed_to_terms do
+      = f.check_box :agreed_to_terms
+      = t('authentication.agree_to_terms', terms_link: link_to(t('authentication.terms'), terms_path)).html_safe
 
   = f.submit t("authentication.sign_up"), :class => 'btn btn-primary'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -16,6 +16,9 @@
     %div
       Currently waiting confirmation for: #{resource.unconfirmed_email}
   .form-field
+    = f.label :organization
+    = f.text_field :organization, :class => 'span8'
+  .form-field
     = f.label :current_password
     %i= t("authentication.current_password_info")
     = f.password_field :current_password, :class => 'span8'
@@ -26,6 +29,10 @@
   .form-field
     = f.label :password_confirmation
     = f.password_field :password_confirmation, :class => 'span8'
+  .form-field.check_box
+    = f.label :agreed_to_terms do
+      = f.check_box :agreed_to_terms
+      = t('authentication.agree_to_terms', terms_link: link_to(t('authentication.terms'), terms_path)).html_safe
   .form-field
     = f.label :default_jurisdiction
     = f.select(:default_jurisdiction, jurisdiction_options_for_select(resource.default_jurisdiction))

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -19,9 +19,8 @@
     = f.label :organization
     = f.text_field :organization, :class => 'span8'
   .form-field
-    = f.label :current_password
-    %i= t("authentication.current_password_info")
-    = f.password_field :current_password, :class => 'span8'
+    = f.label :default_jurisdiction
+    = f.select(:default_jurisdiction, jurisdiction_options_for_select(resource.default_jurisdiction))
   .form-field
     = f.label :password
     %i= t("authentication.new_password_info")
@@ -34,10 +33,12 @@
       = f.check_box :agreed_to_terms
       = t('authentication.agree_to_terms', terms_link: link_to(t('authentication.terms'), terms_path)).html_safe
   .form-field
-    = f.label :default_jurisdiction
-    = f.select(:default_jurisdiction, jurisdiction_options_for_select(resource.default_jurisdiction))
+    = f.label :current_password
+    %i= t("authentication.current_password_info")
+    = f.password_field :current_password, :class => 'span8'
 
-  = f.submit t("authentication.update_profile"), :class => 'btn btn-primary'
+  = f.submit t("authentication.update_profile"), :class => 'btn btn-primary btn-large'
+
 
 .well
   = form_for(resource, :as => resource_name, :url => '') do |f|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -306,6 +306,8 @@ en:
     new_password_info: (leave blank if you don't want to change it)
     already_have_account: Already have an account?
     resend_confirmation_instructions: Resend confirmation instructions
+    agree_to_terms: "I've read and agree to the %{terms_link}."
+    terms: Terms of use
 
   about:
     heading_about: About

--- a/db/migrate/20150119114745_add_extra_user_details.rb
+++ b/db/migrate/20150119114745_add_extra_user_details.rb
@@ -1,7 +1,7 @@
 class AddExtraUserDetails < ActiveRecord::Migration
   def up
     add_column :users, :organization, :string
-    add_column :users, :agreed_to_terms, :boolean, null: false, default: false
+    add_column :users, :agreed_to_terms, :boolean, null: true, default: nil
   end
 
   def down

--- a/db/migrate/20150119114745_add_extra_user_details.rb
+++ b/db/migrate/20150119114745_add_extra_user_details.rb
@@ -1,0 +1,11 @@
+class AddExtraUserDetails < ActiveRecord::Migration
+  def up
+    add_column :users, :organization, :string
+    add_column :users, :agreed_to_terms, :boolean, null: false, default: false
+  end
+
+  def down
+    remove_column :users, :organization
+    remove_column :users, :agreed_to_terms
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -417,7 +417,7 @@ ActiveRecord::Schema.define(:version => 20150119114745) do
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
     t.string   "organization"
-    t.boolean  "agreed_to_terms",        :default => false, :null => false
+    t.boolean  "agreed_to_terms"
   end
 
   add_index "users", ["authentication_token"], :name => "index_users_on_authentication_token", :unique => true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150112104243) do
+ActiveRecord::Schema.define(:version => 20150119114745) do
 
   create_table "answers", :force => true do |t|
     t.integer  "question_id"
@@ -416,6 +416,8 @@ ActiveRecord::Schema.define(:version => 20150112104243) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
+    t.string   "organization"
+    t.boolean  "agreed_to_terms",        :default => false, :null => false
   end
 
   add_index "users", ["authentication_token"], :name => "index_users_on_authentication_token", :unique => true

--- a/features/agreeing_to_terms.feature
+++ b/features/agreeing_to_terms.feature
@@ -1,0 +1,22 @@
+Feature: agreeing to terms of use
+
+  Background:
+    Given I am signed in as "robyn@example.org"
+    And I visit the edit account page
+
+  Scenario: I need to agree to the terms of use to save my details
+    When I enter an organization of "Example Org"
+    And I do not agree to the terms
+    And I enter my password
+    And I click save
+    Then there is an error message about agreeing to terms
+    And my changes are not saved
+
+  Scenario: I agree to terms of use and save my details
+    When I enter an organization of "Example Org"
+    And I agree to the terms
+    And I enter my password
+    And I click save
+    Then there is no error message
+    And my changes are saved
+

--- a/features/step_definitions/certificate_steps.rb
+++ b/features/step_definitions/certificate_steps.rb
@@ -5,7 +5,7 @@ def get_user(email)
 end
 
 When(/^I am signed in as "(.*?)"$/) do |email|
-  get_user(email)
+  @user = get_user(email)
   visit '/users/sign_in'
   first('#main #user_email').set(email)
   first('#main #user_password').set("password")

--- a/features/step_definitions/user_details.rb
+++ b/features/step_definitions/user_details.rb
@@ -1,0 +1,40 @@
+Given(/^I visit the edit account page$/) do
+  visit edit_user_registration_path(@user)
+end
+
+When(/^I enter an organization of "(.*?)"$/) do |organization|
+  @organization = organization
+  first('#user_organization').set(organization)
+end
+
+When(/^I agree to the terms$/) do
+  first('#user_agreed_to_terms').set(true)
+end
+
+When(/^I do not agree to the terms$/) do
+  first('#user_agreed_to_terms').set(false)
+end
+
+When(/^I enter my password$/) do
+  first('#user_current_password').set('password')
+end
+
+When(/^I click save$/) do
+  click_on 'Update my profile'
+end
+
+Then(/^there is an error message about agreeing to terms$/) do
+  assert_text('Errors occurred')
+end
+
+Then(/^there is no error message$/) do
+  assert_no_text('Errors occurred')
+end
+
+Then(/^my changes are saved$/) do
+  assert_equal @organization, @user.reload.organization
+end
+
+Then(/^my changes are not saved$/) do
+  refute_equal @organization, @user.reload.organization
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -101,4 +101,16 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "Joan Jett <joan@example.com>", user.to_s
   end
 
+  test "can create a user without specifying agreement to terms" do
+    assert User.new(email: 'robyn@example.com', password: 'password').valid?
+  end
+
+  test "can create a user that agreeds to terms" do
+    assert User.new(email: 'robyn@example.com', password: 'password', agreed_to_terms: true).valid?
+  end
+
+  test "not agreeing to terms prevents saving" do
+    refute User.new(email: 'robyn@example.com', password: 'password', agreed_to_terms: false).valid?
+  end
+
 end


### PR DESCRIPTION
Save users agreement to Terms of use and the Organization they represent.

Satisfies requirements for #872 but not quite for #865 yet.