### PR TITLE
Include User Agent and IP in certificate report email

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -93,7 +93,13 @@ class CertificatesController < ApplicationController
   end
 
   def report
-    @certificate.report!(params[:reasons], params[:email])
+    reasons, email = params.values_at(:reasons, :email)
+    reporter = {
+      email: email,
+      remote_ip: request.remote_ip,
+      user_agent: request.env['HTTP_USER_AGENT']
+    }
+    @certificate.report!(params[:reasons], reporter)
 
     flash[:notice] = I18n.t('certificates.flashes.reported')
     redirect_to dataset_certificate_path(params[:dataset_id], @certificate)

--- a/app/mailers/certificate_mailer.rb
+++ b/app/mailers/certificate_mailer.rb
@@ -5,7 +5,9 @@ class CertificateMailer < ActionMailer::Base
   def report(certificate, reason, reporter)
     @certificate = certificate
     @reason = reason
-    from = reporter.presence || Devise.mailer_sender
+    @reporter = reporter
+    from = @reporter[:email].presence || Devise.mailer_sender
+
     mail(subject: "Reported certificate: #{certificate.name}", to: Devise.mailer_sender, from: from)
   end
   

--- a/app/views/certificate_mailer/report.text.erb
+++ b/app/views/certificate_mailer/report.text.erb
@@ -8,3 +8,8 @@ This certificate has been reported as having a problem:
 <%= "-" * [@certificate.name.size, 80].min %>
 
 <%= @certificate.url %>
+
+<%= "-" * [@certificate.name.size, 80].min %>
+
+IP address: <%= @reporter[:remote_ip] %>
+User Agent: <%= @reporter[:user_agent] %>


### PR DESCRIPTION
As we are getting spam reports track them so we can decide to block them at the ip level.

Other options is to rate limit requests from the same ip to that end point, which could be done in memory in the app as a basic defence.

Closes #1021 