### PR TITLE
handle more request errors

### DIFF
--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -219,12 +219,7 @@ class ResponseSet < ActiveRecord::Base
 
   def licence_from_ref(ref)
     case ref
-    when nil
-      {
-        :title => "Not Applicable",
-        :url => nil
-      }
-    when "na"
+    when nil, "na"
       {
         :title => "Not Applicable",
         :url => nil

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -240,12 +240,16 @@ class ResponseSet < ActiveRecord::Base
       end
     else
       failure = {:title => 'Unknown', :url => nil}
-      ODIBot.handle_errors(failure) do
-        licence = Odlifier::License.define(REF_CHANGES[ref] || ref.dasherize)
+      begin
+        licence = ODIBot.handle_errors(failure) do
+          Odlifier::License.define(REF_CHANGES[ref] || ref.dasherize)
+        end
         {
           :title => licence.title,
           :url   => licence.url
         }
+      rescue ArgumentError
+        failure
       end
     end
   end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -209,15 +209,16 @@ class ResponseSet < ActiveRecord::Base
 
   # Custom getter which chooses an appropriate data licence
   def data_licence_determined_from_responses
-    @data_licence_determined_from_responses ||= licence_from_ref(value_for(:data_licence, :reference_identifier))
+    @data_licence_determined_from_responses ||= licence_from_ref(:data_licence)
   end
 
   # Custom getter which chooses an appropriate content licence
   def content_licence_determined_from_responses
-    @content_licence_determined_from_responses ||= licence_from_ref(value_for(:content_licence, :reference_identifier))
+    @content_licence_determined_from_responses ||= licence_from_ref(:content_licence)
   end
 
-  def licence_from_ref(ref)
+  def licence_from_ref(licence_type)
+    ref = value_for(licence_type, :reference_identifier)
     case ref
     when nil, "na"
       {
@@ -225,10 +226,18 @@ class ResponseSet < ActiveRecord::Base
         :url => nil
       }
     when "other"
-      {
-        :title => value_for(:other_content_licence_name),
-        :url   => value_for(:other_content_licence_url)
-      }
+      case licence_type
+      when :data_licence
+        {
+          :title => value_for(:other_dataset_licence_name),
+          :url   => value_for(:other_dataset_licence_url)
+        }
+      when :content_licence
+        {
+          :title => value_for(:other_content_licence_name),
+          :url   => value_for(:other_content_licence_url)
+        }
+      end
     else
       failure = {:title => 'Unknown', :url => nil}
       ODIBot.handle_errors(failure) do

--- a/lib/odibot.rb
+++ b/lib/odibot.rb
@@ -9,14 +9,14 @@ class ODIBot
   end
 
   def response_code
-    code = Rails.cache.fetch(@url) rescue nil
-    if code.nil?
-      code = self.class.get(@url, @options).code
-      Rails.cache.write(@url, code, expires_in: 5.minute)
+    ODIBot.handle_errors(0) do
+      code = Rails.cache.fetch(@url) rescue nil
+      if code.nil?
+        code = self.class.get(@url, @options).code
+        Rails.cache.write(@url, code, expires_in: 5.minute)
+      end
+      code
     end
-    code
-  rescue SocketError, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError, Timeout::Error
-    0
   end
 
   def is_http_url?
@@ -33,5 +33,11 @@ class ODIBot
 
   def valid?
     is_http_url? && response_code == 200
+  end
+
+  def self.handle_errors(return_value)
+    return yield
+  rescue SocketError, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError, Timeout::Error
+    return return_value
   end
 end

--- a/lib/odibot.rb
+++ b/lib/odibot.rb
@@ -20,7 +20,13 @@ class ODIBot
   end
 
   def is_http_url?
-    URI.parse(@url).kind_of?(URI::HTTP)
+    uri = URI.parse(@url)
+    if uri.kind_of?(URI::HTTP)
+      hostname = uri.hostname
+      hostname.present? && hostname.include?('.')
+    else
+      false
+    end
   rescue URI::InvalidURIError
     false
   end

--- a/lib/odibot.rb
+++ b/lib/odibot.rb
@@ -15,7 +15,7 @@ class ODIBot
       Rails.cache.write(@url, code, expires_in: 5.minute)
     end
     code
-  rescue SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError, Timeout::Error
+  rescue SocketError, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError, Timeout::Error
     0
   end
 

--- a/test/unit/odibot_test.rb
+++ b/test/unit/odibot_test.rb
@@ -75,7 +75,7 @@ class ODIBotTest < ActiveSupport::TestCase
     refute ODIBot.new("foo bar").valid?
   end
 
-  [SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError, Timeout::Error].each do |error|
+  [SocketError, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError, Timeout::Error].each do |error|
     test "handles #{error.name}" do
       stub_request(:get, "http://www.example.com").to_raise(error)
       refute ODIBot.new("http://www.example.com").valid?

--- a/test/unit/odibot_test.rb
+++ b/test/unit/odibot_test.rb
@@ -75,6 +75,13 @@ class ODIBotTest < ActiveSupport::TestCase
     refute ODIBot.new("foo bar").valid?
   end
 
+  test "checks if url is specified enough to request" do
+    ODIBot.expects(:get).never
+    refute ODIBot.new("http://").valid?
+    refute ODIBot.new("http:///").valid?
+    refute ODIBot.new("http://notadomain").valid?
+  end
+
   [SocketError, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError, Timeout::Error].each do |error|
     test "handles #{error.name}" do
       stub_request(:get, "http://www.example.com").to_raise(error)


### PR DESCRIPTION
Wrap external requests in a handler that catches all common transport errors.


This doesn't add retry logic as even having external requests in the request response cycle isn't a good idea but that's harder to refactor at for the moment.