### PR TITLE
Certificate csv download stored on rackspace

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -90,14 +90,7 @@ class DatasetsController < ApplicationController
         format.feed { render :layout => false  }
         format.csv do
           raise ActiveRecord::RecordNotFound if search_filtered?
-          begin
-            send_file Rails.root.join("public/system/datasets.csv"),
-              type: 'text/csv; headers=present',
-              disposition: 'attachment',
-              filename: 'open-data-certificates.csv'
-          rescue ActionController::MissingFile
-            raise ActiveRecord::RecordNotFound
-          end
+          redirect_to CSVExport.download_url
         end
       end
     end

--- a/lib/extra/csv_export.rb
+++ b/lib/extra/csv_export.rb
@@ -1,15 +1,33 @@
 module CSVExport
   extend RecurringJob
 
-  PATH = Rails.root.join('public/system/datasets.csv')
+  FILENAME = 'open-data-certificates.csv'
+  METADATA = {
+    content_type: 'text/csv',
+    content_disposition: 'attachment'
+  }
 
   def self.perform
     reenqueue_job do
-      DatasetsCSV.new(Dataset.visible).save(PATH)
+      begin
+        tmp = Tempfile.new('datasets.csv')
+        DatasetsCSV.new(Dataset.visible).save(tmp.path)
+        Rackspace.upload(FILENAME, File.open(tmp.path), METADATA)
+      ensure
+        tmp.close!
+      end
     end
   end
 
   def self.next_run_date
     DateTime.now.utc.tomorrow.beginning_of_day + 3.hours
+  end
+
+  def self.download_url
+    if file = Rackspace.dir.files.head(FILENAME)
+      file.public_url
+    else
+      raise ActiveRecord::RecordNotFound
+    end
   end
 end

--- a/lib/extra/rackspace.rb
+++ b/lib/extra/rackspace.rb
@@ -15,9 +15,9 @@ module Rackspace
     service.directories.get ENV['RACKSPACE_CERTIFICATE_DUMP_CONTAINER']
   end
 
-  def self.upload(filename, body)
+  def self.upload(filename, body, headers={})
     dir = service.directories.get ENV['RACKSPACE_CERTIFICATE_DUMP_CONTAINER']
-    dir.files.create :key => filename, :body => body
+    dir.files.create headers.merge(:key => filename, :body => body)
   end
   
   def self.fetch_cache(file, expires = 12.hour)

--- a/test/unit/csv_export_test.rb
+++ b/test/unit/csv_export_test.rb
@@ -6,6 +6,7 @@ class CSVExportTest < ActiveSupport::TestCase
     next_time = DateTime.now.utc.tomorrow.beginning_of_day + 3.hours
     Delayed::Job.expects(:enqueue).with(CSVExport, has_entries(:run_at => next_time))
     DatasetsCSV.any_instance.stubs(:save)
+    Rackspace.stubs(:upload)
     CSVExport.perform
   end
 
@@ -13,15 +14,43 @@ class CSVExportTest < ActiveSupport::TestCase
     next_time = DateTime.now.utc.tomorrow.beginning_of_day + 3.hours
     Delayed::Job.expects(:enqueue).with(CSVExport, has_entries(:run_at => next_time))
     DatasetsCSV.any_instance.stubs(:save).raises(ArgumentError, 'deliberate failure')
+    Rackspace.stubs(:upload)
     assert_raises ArgumentError do
       CSVExport.perform
     end
   end
 
   test "job is not enqued if there is already one pending" do
+    Rackspace.stubs(:upload)
     DatasetsCSV.any_instance.stubs(:save)
     CSVExport.perform
     Delayed::Job.expects(:enqueue).never
     CSVExport.perform
   end
+
+  test "download_url gets public_url for file" do
+    # Demeterrrrrr!
+    files = mock()
+    dir = mock()
+    Rackspace.stubs(:dir).returns(dir)
+    dir.stubs(:files).returns(files)
+    file = mock()
+    files.expects(:head).with(CSVExport::FILENAME).returns(file)
+    file.expects(:public_url).returns("http://rackspace.example.com/file.csv")
+    
+    assert_equal "http://rackspace.example.com/file.csv", CSVExport.download_url
+  end
+
+  test "download_url raises record not found if file is nil" do
+    # Demeterrrrrr!
+    files = mock()
+    dir = mock()
+    Rackspace.stubs(:dir).returns(dir)
+    dir.stubs(:files).returns(files)
+    files.stubs(:head).returns(nil)
+    assert_raises(ActiveRecord::RecordNotFound) do
+      CSVExport.download_url
+    end
+  end
+
 end


### PR DESCRIPTION
Instead of generating once per node on local storage, store in rackspace cloud and redirect to it