### PR TITLE
Report DelayedJob errors to Airbrake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :production do
   gem 'foreman'
   gem 'mysql2'
   gem 'airbrake'
+  gem 'delayed-plugins-airbrake'
   gem 'memcache-client'
   gem 'logstash-event'
   gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       json
       json-schema
       rest-client
+    delayed-plugins-airbrake (1.1.0)
+      airbrake
+      delayed_job
     delayed_job (4.0.0)
       activesupport (>= 3.0, < 4.1)
     delayed_job_active_record (4.0.0)
@@ -473,6 +476,7 @@ DEPENDENCIES
   cucumber-rails
   data_kitten
   database_cleaner
+  delayed-plugins-airbrake
   delayed_job_active_record
   devise (= 3.0.3)
   domainatrix

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -6,4 +6,7 @@ if ENV['AIRBRAKE_CERTIFICATE_KEY']
     # displayed in the 500.html error page
     config.user_information = "Exception ID <strong>{{ error_id }}</strong>"
   end
+
+  require 'delayed-plugins-airbrake'
+  Delayed::Worker.plugins << Delayed::Plugins::Airbrake::Plugin
 end


### PR DESCRIPTION
Pretty sure a bunch of errors have been hidden as delayed job isn't wrapped by an airbrake handler by default