### PR TITLE
Generate a public url for csv download url

### DIFF
--- a/lib/extra/csv_export.rb
+++ b/lib/extra/csv_export.rb
@@ -4,7 +4,8 @@ module CSVExport
   FILENAME = 'open-data-certificates.csv'
   METADATA = {
     content_type: 'text/csv',
-    content_disposition: 'attachment'
+    content_disposition: 'attachment',
+    public: true
   }
 
   def self.perform


### PR DESCRIPTION
on staging the url was not being generated as public but is on production.

Add a specifier to make sure they are always created as public.