### PR TITLE
Fixed nested code markup in translation HOWTO

### DIFF
--- a/prototype/HOWTO.md
+++ b/prototype/HOWTO.md
@@ -16,9 +16,9 @@ and this should update translations
 first and third columns of the first worksheet  (The reference and the translation),
 and separate them by a colon and a space `: ` and save in `temp`
 
-    # note path to {sheet1 filename} is relative to the location of auto-translate.xsl
-    # {country code} is in capitals, eg. MX, CZ
-    saxon -s:prototype/jurisdictions/certificate.{country code}.xml -xsl:prototype/auto-translate.xsl -o:prototype/temp/certificate.{country code}.xml translationFile=temp/{sheet1 filename}
+        # note path to {sheet1 filename} is relative to the location of auto-translate.xsl
+        # {country code} is in capitals, eg. MX, CZ
+        saxon -s:prototype/jurisdictions/certificate.{country code}.xml -xsl:prototype/auto-translate.xsl -o:prototype/temp/certificate.{country code}.xml translationFile=temp/{sheet1 filename}
 
 2. Verify that the translation has worked, and then move the resulting file to
 the `jurisdictions` directory
@@ -27,13 +27,12 @@ the `jurisdictions` directory
 
 4. Run the following:
 
-    # note {language code} is lower case, eg. en, cz
-    saxon -s:prototype/translations/certificate.en.xml -xsl:prototype/auto-translate.xsl -o:prototype/temp/certificate.{language code}.xml translationFile=temp/{sheet2 filename}
-    # then you need to edit the resulting certificate.cz.xml file and change the `xml:lang` property to `lang` from `en`
+        # note {language code} is lower case, eg. en, cz
+        saxon -s:prototype/translations/certificate.en.xml -xsl:prototype/auto-translate.xsl -o:prototype/temp/certificate.{language code}.xml translationFile=temp/{sheet2 filename}
+        # then you need to edit the resulting certificate.cz.xml file and change the `xml:lang` property to `lang` from `en`
 
-5. Verify that the translation has worked, and then move the resulting file to
-the `translations` directory
+5. Verify that the translation has worked, and then move the resulting file to the `translations` directory
 
 6. Finally, run:
 
-    saxon -s:prototype/jurisdictions/ -xsl:prototype/surveyor.xsl -o:prototype/temp/
+        saxon -s:prototype/jurisdictions/ -xsl:prototype/surveyor.xsl -o:prototype/temp/


### PR DESCRIPTION
Four spaces was not enough since the Markup parser interpreted that (correctly) as a block continuation in the bulleted list.