### PR TITLE
refactor CertificateGenerator

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -196,7 +196,8 @@ class DatasetsController < ApplicationController
           success: false,
           published: false,
           dataset_id: generator.dataset.id,
-          dataset_url: status_datasets_url(generator)
+          dataset_url: status_datasets_url(generator),
+          errors: generator.response_errors
         }
       end
     else
@@ -242,6 +243,7 @@ class DatasetsController < ApplicationController
 
   def no_published_certificate_exists
     documentation_url = params[:dataset][:documentationUrl]
+    return unless documentation_url.present?
     existing_dataset = Dataset.where(documentation_url: documentation_url).first
     if existing_dataset.try(:certificate).present?
       campaign.increment!(:duplicate_count) if campaign

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,11 +4,7 @@ class Ability
   def initialize(user)
     
     can :manage, ResponseSet do |response_set|
-      response_set.nil? ||
-        (
-        response_set.user.nil? ||
-        response_set.user == user
-        )
+      response_set.nil? || response_set.unowned_or_by?(user)
     end
     
     can :read, Dataset do |dataset|
@@ -16,7 +12,7 @@ class Ability
     end
 
     can :manage, Dataset do |dataset|
-      dataset.user.nil? || dataset.owned_by?(user)
+      dataset.unowned_or_by?(user)
     end
 
     can :claim, Certificate do |certificate|
@@ -35,30 +31,27 @@ class Ability
     end
 
     can :manage, Claim do |claim|
-      user.admin? || claim.try(:user) == user
+      user.admin? || claim.owned_by?(user)
     end
 
     can :destroy, Transfer, user: user
 
     can :read, CertificateGenerator do |generator|
-      generator.try(:user) == user
+      generator.owned_by?(user)
     end
 
     can :read, CertificationCampaign do |campaign|
-      campaign.try(:user) == user
+      campaign.owned_by?(user)
     end
 
     can :read, Certificate do |certificate|
-      certificate.visible? || owns(user, certificate)
+      certificate.visible? || certificate.owned_by?(user)
     end
 
     can :manage, Certificate do |certificate|
-      owns(user, certificate)
+      certificate.owned_by?(user)
     end
 
   end
 
-  def owns(user, model)
-    model.user.present? && model.user == user
-  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,13 +12,11 @@ class Ability
     end
     
     can :read, Dataset do |dataset|
-      dataset.visible? || user.try(:admin?) ||
-        (dataset.user.present? && dataset.user == user)
+      dataset.visible? || user.try(:admin?) || dataset.owned_by?(user)
     end
 
     can :manage, Dataset do |dataset|
-      dataset.user.nil? ||
-        dataset.user == user
+      dataset.user.nil? || dataset.owned_by?(user)
     end
 
     can :claim, Certificate do |certificate|

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -3,6 +3,8 @@ class Answer < ActiveRecord::Base
 
   attr_accessible :requirement, :help_text_more_url, :input_type, :placeholder, :text_as_statement
 
+  scope :urls, where(:input_type => 'url')
+
   def message?
     !(message || '').strip.blank?
   end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,5 +1,5 @@
 class Certificate < ActiveRecord::Base
-  include Badges, Counts
+  include Badges, Counts, Ownership
   include AASM
 
   belongs_to :response_set, touch: true

--- a/app/models/certificate_generator.rb
+++ b/app/models/certificate_generator.rb
@@ -60,21 +60,7 @@ class CertificateGenerator < ActiveRecord::Base
     certificate = generator.generate(jurisdiction, false)
     response_set = certificate.response_set
 
-    errors = []
-
-    response_set.responses_with_url_type.each do |response|
-      if response.error
-        errors.push("The question '#{response.question.reference_identifier}' must have a valid URL")
-      end
-    end
-
-    survey.questions.where(is_mandatory: true).each do |question|
-      response = response_set.responses.detect {|r| r.question_id == question.id}
-
-      if !response || response.empty?
-        errors.push("The question '#{question.reference_identifier}' is mandatory")
-      end
-    end
+    errors = response_set.response_errors
 
     {success: true, published: response_set.published?, errors: errors}
   end

--- a/app/models/certificate_generator.rb
+++ b/app/models/certificate_generator.rb
@@ -113,6 +113,10 @@ class CertificateGenerator < ActiveRecord::Base
     certificate.try(:published?)
   end
 
+  def response_errors
+    response_set.response_errors
+  end
+
   def dataset_url
     dataset.api_url
   end

--- a/app/models/certificate_generator.rb
+++ b/app/models/certificate_generator.rb
@@ -1,4 +1,5 @@
 class CertificateGenerator < ActiveRecord::Base
+  include Ownership
 
   belongs_to :user
   belongs_to :response_set

--- a/app/models/certification_campaign.rb
+++ b/app/models/certification_campaign.rb
@@ -1,4 +1,5 @@
 class CertificationCampaign < ActiveRecord::Base
+  include Ownership
   validates :name, uniqueness: true, presence: true
 
   has_many :certificate_generators

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,5 +1,6 @@
 class Claim < ActiveRecord::Base
   include AASM
+  include Ownership
 
   DELIVERY_ADMIN_OVERRIDE = true
 

--- a/app/models/concerns/badges.rb
+++ b/app/models/concerns/badges.rb
@@ -1,17 +1,19 @@
 module Badges
   extend ActiveSupport::Concern
 
-  def self.badge_file_for_level(level)
-    filename = case level
-                 when 'basic'
-                   'raw_level_badge.png'
-                 when 'raw', 'pilot', 'standard', 'exemplar'
-                   "#{level}_level_badge.png"
-                 else
-                   'no_level_badge.png'
-               end
+  module ClassMethods
+    def badge_file_for_level(level)
+      filename = case level
+      when 'basic'
+        'raw_level_badge.png'
+      when 'raw', 'pilot', 'standard', 'exemplar'
+        "#{level}_level_badge.png"
+      else
+        'no_level_badge.png'
+      end
 
-    File.open(File.join(Rails.root, 'app/assets/images/badges', filename))
+      File.open(File.join(Rails.root, 'app/assets/images/badges', filename))
+    end
   end
 
   def badge_file

--- a/app/models/concerns/counts.rb
+++ b/app/models/concerns/counts.rb
@@ -1,10 +1,6 @@
 module Counts
   extend ActiveSupport::Concern
 
-  def self.included(base)
-    base.extend(ClassMethods)
-  end
-
   module ClassMethods
 
     def counts

--- a/app/models/concerns/ownership.rb
+++ b/app/models/concerns/ownership.rb
@@ -1,0 +1,16 @@
+module Ownership
+  extend ActiveSupport::Concern
+
+  def owned_by?(account)
+    user.present? && user == account
+  end
+
+  def unowned?
+    user.nil?
+  end
+
+  def unowned_or_by?(account)
+    unowned? || owned_by?(account)
+  end
+
+end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -113,21 +113,7 @@ class Dataset < ActiveRecord::Base
     response_set = newest_response_set
 
     if response_set.certificate_generator && response_set.certificate_generator.completed?
-      errors = []
-
-      response_set.responses_with_url_type.each do |response|
-        if response.error
-          errors.push("The question '#{response.question.reference_identifier}' must have a valid URL")
-        end
-      end
-
-      response_set.survey.questions.where(is_mandatory: true).each do |question|
-        response = response_set.responses.detect {|r| r.question_id == question.id}
-
-        if !response || response.empty?
-          errors.push("The question '#{question.reference_identifier}' is mandatory")
-        end
-      end
+      errors = response_set.response_errors
 
       certificate_url = certificate.url(format: :json) if certificate
 

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -140,4 +140,8 @@ class Dataset < ActiveRecord::Base
     response_sets.update_all(user_id: user.id)
   end
 
+  def owned_by?(account)
+    user.present? && user == account
+  end
+
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -1,4 +1,5 @@
 class Dataset < ActiveRecord::Base
+  include Ownership
   belongs_to :user
 
   delegate :name, :email, :to => :user, :prefix => true, :allow_nil => true
@@ -138,10 +139,6 @@ class Dataset < ActiveRecord::Base
   def change_owner!(user)
     update_attribute(:user_id, user.id)
     response_sets.update_all(user_id: user.id)
-  end
-
-  def owned_by?(account)
-    user.present? && user == account
   end
 
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -6,6 +6,7 @@ class Question < ActiveRecord::Base
 
   scope :excluding, lambda { |*objects| where(['questions.id NOT IN (?)', (objects.flatten.compact << 0)]) }
   scope :mandatory, where(is_mandatory: true)
+  scope :urls, joins(:answers).merge(Answer.urls)
 
   before_save :cache_question_or_answer_corresponding_to_requirement
   before_save :set_default_value_for_required

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -14,6 +14,13 @@ class Response < ActiveRecord::Base
 
   before_save :resolve_if_url
 
+  scope :filled, joins(:question).where(<<-SQL)
+    CASE questions.pick
+    WHEN 'none' THEN trim(string_value) != ''
+    ELSE answer_id is not null
+    END
+  SQL
+
   def sibling_responses(responses)
     (responses || []).select{|r| r.question_id == question_id && r.response_set_id == response_set_id}
   end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -3,6 +3,7 @@ require 'odibot'
 class ResponseSet < ActiveRecord::Base
   include Surveyor::Models::ResponseSetMethods
   include AASM
+  include Ownership
 
   # Surveyor field types
   VALUE_FIELDS = [:datetime_value, :integer_value, :float_value, :unit, :text_value, :string_value]

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -258,7 +258,7 @@ class ResponseSet < ActiveRecord::Base
   end
 
   def incomplete_triggered_mandatory_questions
-    responded_to_question_ids = responses.pluck('question_id')
+    responded_to_question_ids = responses.filled.pluck('question_id')
     triggered_mandatory_questions.reject { |q| responded_to_question_ids.include? q.id }
   end
 

--- a/test/unit/certificate_generator_test.rb
+++ b/test/unit/certificate_generator_test.rb
@@ -112,7 +112,7 @@ class CertificateGeneratorTest < ActiveSupport::TestCase
       response = CertificateGenerator.update(Dataset.last, update, 'cert-generator', @user)
       assert_equal(true, response[:success])
       assert_equal(true, response[:published])
-      assert_equal([], response[:errors])
+      assert_equal({}, response[:errors])
     end
   end
 
@@ -147,14 +147,14 @@ class CertificateGeneratorTest < ActiveSupport::TestCase
       response = CertificateGenerator.update(Dataset.last, update, 'cert-generator', @user)
       assert_equal(true, response[:success])
       assert_equal(false, response[:published])
-      assert_equal(["The question 'publisherUrl' is mandatory"], response[:errors])
+      assert_equal({'publisherUrl' => ['mandatory']}, response[:errors])
     end
 
     assert_no_difference 'ResponseSet.count' do
       response = CertificateGenerator.update(Dataset.last, update, 'cert-generator', @user)
       assert_equal(true, response[:success])
       assert_equal(false, response[:published])
-      assert_equal(["The question 'publisherUrl' is mandatory"], response[:errors])
+      assert_equal({'publisherUrl' => ['mandatory']}, response[:errors])
     end
   end
 
@@ -187,7 +187,7 @@ class CertificateGeneratorTest < ActiveSupport::TestCase
         response = CertificateGenerator.update(Dataset.last, update, 'cert-generator', @user)
         assert_equal(true, response[:success])
         assert_equal(false, response[:published])
-        assert_equal(["The question 'favouriteAnimal' is mandatory"], response[:errors])
+        assert_equal({'favouriteAnimal' => ['mandatory']}, response[:errors])
       end
     end
 

--- a/test/unit/dataset_test.rb
+++ b/test/unit/dataset_test.rb
@@ -144,7 +144,7 @@ class DatasetTest < ActiveSupport::TestCase
     assert_equal(true, response[:success])
     assert_equal(true, response[:published])
     assert_equal(user.email, response[:owner_email])
-    assert_equal([], response[:errors])
+    assert_equal({}, response[:errors])
   end
 
   test 'get results of certificate with missing field' do
@@ -165,7 +165,7 @@ class DatasetTest < ActiveSupport::TestCase
 
     assert_equal(true, response[:success])
     assert_equal(false, response[:published])
-    assert_equal(["The question 'dataTitle' is mandatory"], response[:errors])
+    assert_equal({'dataTitle' => ['mandatory']}, response[:errors])
   end
 
   test 'get results of certificate with invalid URL' do
@@ -190,7 +190,7 @@ class DatasetTest < ActiveSupport::TestCase
 
     assert_equal(true, response[:success])
     assert_equal(false, response[:published])
-    assert_equal(["The question 'publisherUrl' must have a valid URL"], response[:errors])
+    assert_equal({'publisherUrl' => ['invalid-url']}, response[:errors])
   end
 
   test "doesn't show results when generation hasn't happened" do
@@ -213,7 +213,7 @@ class DatasetTest < ActiveSupport::TestCase
     assert_equal(true, response[:success])
     assert_equal(true, response[:published])
     assert_equal(user.email, response[:owner_email])
-    assert_equal([], response[:errors])
+    assert_equal({}, response[:errors])
   end
 
   test "generation result for unclaimed certificate" do
@@ -235,7 +235,7 @@ class DatasetTest < ActiveSupport::TestCase
     assert_equal(true, response[:success])
     assert_equal(true, response[:published])
     assert_equal(nil, response[:owner_email])
-    assert_equal([], response[:errors])
+    assert_equal({}, response[:errors])
   end
 
   test 'returns an api_url' do


### PR DESCRIPTION
Generate error messages in only one place.

Change them to be slightly more machine readable too.
Clean up some ownership testing code
Make sure all `ActiveSupport::Concern`s are used as they should be