### PR TITLE
Deploy 2015-05-07

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ gem 'redcarpet'
 gem "devise", "3.0.3"
 gem 'dotenv-rails'
 gem 'httparty'
-gem 'data_kitten'
+gem 'data_kitten', github: 'theodi/data_kitten'
 gem 'delayed_job_active_record'
 gem 'linkeddata'
 gem 'rack-linkeddata'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,20 @@ GIT
       open_uri_redirections
 
 GIT
+  remote: git://github.com/theodi/data_kitten.git
+  revision: ddcbb677d7d993091a8f2ca44e537aa5cfd63bb8
+  specs:
+    data_kitten (1.2.0)
+      curb
+      datapackage
+      git
+      json
+      linkeddata
+      nokogiri
+      rake
+      rest-client
+
+GIT
   remote: git://github.com/theodi/juvia_rails.git
   revision: 94f982aa8188a18bc0f37c16218c85e890d25294
   specs:
@@ -100,17 +114,8 @@ GEM
       mime-types (~> 1.16)
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
-    curb (0.8.6)
+    curb (0.8.8)
     daemons (1.1.9)
-    data_kitten (1.0.2)
-      curb
-      datapackage
-      git
-      json
-      linkeddata
-      nokogiri
-      rake
-      rest-client
     database_cleaner (1.3.0)
     datapackage (0.0.4)
       colorize
@@ -173,7 +178,7 @@ GEM
       actionpack (~> 3.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    git (1.2.8)
+    git (1.2.9.1)
     google_drive (0.3.9)
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
       oauth (>= 0.3.6)
@@ -206,7 +211,8 @@ GEM
     json (1.8.1)
     json-ld (1.1.6)
       rdf (~> 1.1, >= 1.1.4)
-    json-schema (2.2.5)
+    json-schema (2.5.0)
+      addressable (~> 2.3)
     jwt (0.1.13)
       multi_json (>= 1.5)
     kaminari (0.15.1)
@@ -476,7 +482,7 @@ DEPENDENCIES
   coveralls
   csvlint!
   cucumber-rails
-  data_kitten
+  data_kitten!
   database_cleaner
   delayed-plugins-airbrake
   delayed_job_active_record

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -196,7 +196,8 @@ class DatasetsController < ApplicationController
           success: false,
           published: false,
           dataset_id: generator.dataset.id,
-          dataset_url: status_datasets_url(generator)
+          dataset_url: status_datasets_url(generator),
+          errors: generator.response_errors
         }
       end
     else
@@ -242,6 +243,7 @@ class DatasetsController < ApplicationController
 
   def no_published_certificate_exists
     documentation_url = params[:dataset][:documentationUrl]
+    return unless documentation_url.present?
     existing_dataset = Dataset.where(documentation_url: documentation_url).first
     if existing_dataset.try(:certificate).present?
       campaign.increment!(:duplicate_count) if campaign

--- a/app/exporters/datasets_csv.rb
+++ b/app/exporters/datasets_csv.rb
@@ -41,7 +41,7 @@ class DatasetsCSV
       response_set.dataset_curator_determined_from_responses,
       response_set.data_licence_determined_from_responses[:url],
       response_set.content_licence_determined_from_responses[:url],
-      (response_set.documentation_url.string_value if response_set.documentation_url)
+      (response_set.documentation_url.data_value if response_set.documentation_url)
     ]
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,21 +4,15 @@ class Ability
   def initialize(user)
     
     can :manage, ResponseSet do |response_set|
-      response_set.nil? ||
-        (
-        response_set.user.nil? ||
-        response_set.user == user
-        )
+      response_set.nil? || response_set.unowned_or_by?(user)
     end
     
     can :read, Dataset do |dataset|
-      dataset.visible? || user.try(:admin?) ||
-        (dataset.user.present? && dataset.user == user)
+      dataset.visible? || user.try(:admin?) || dataset.owned_by?(user)
     end
 
     can :manage, Dataset do |dataset|
-      dataset.user.nil? ||
-        dataset.user == user
+      dataset.unowned_or_by?(user)
     end
 
     can :claim, Certificate do |certificate|
@@ -37,30 +31,27 @@ class Ability
     end
 
     can :manage, Claim do |claim|
-      user.admin? || claim.try(:user) == user
+      user.admin? || claim.owned_by?(user)
     end
 
     can :destroy, Transfer, user: user
 
     can :read, CertificateGenerator do |generator|
-      generator.try(:user) == user
+      generator.owned_by?(user)
     end
 
     can :read, CertificationCampaign do |campaign|
-      campaign.try(:user) == user
+      campaign.owned_by?(user)
     end
 
     can :read, Certificate do |certificate|
-      certificate.visible? || owns(user, certificate)
+      certificate.visible? || certificate.owned_by?(user)
     end
 
     can :manage, Certificate do |certificate|
-      owns(user, certificate)
+      certificate.owned_by?(user)
     end
 
   end
 
-  def owns(user, model)
-    model.user.present? && model.user == user
-  end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -33,4 +33,8 @@ class Answer < ActiveRecord::Base
      :placeholder => self.placeholder,
     }.with_indifferent_access
   end
+
+  def value_key
+    input_type == 'url' ? :text_value : :string_value
+  end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -3,6 +3,8 @@ class Answer < ActiveRecord::Base
 
   attr_accessible :requirement, :help_text_more_url, :input_type, :placeholder, :text_as_statement
 
+  scope :urls, where(:input_type => 'url')
+
   def message?
     !(message || '').strip.blank?
   end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,5 +1,5 @@
 class Certificate < ActiveRecord::Base
-  include Badges, Counts
+  include Badges, Counts, Ownership
   include AASM
 
   belongs_to :response_set, touch: true

--- a/app/models/certificate_generator.rb
+++ b/app/models/certificate_generator.rb
@@ -165,7 +165,7 @@ class CertificateGenerator < ActiveRecord::Base
       response_set.responses.create({
         answer: answer,
         question: question,
-        string_value: data
+        answer.value_key => data
       })
 
     when :one
@@ -197,7 +197,7 @@ class CertificateGenerator < ActiveRecord::Base
         response_set.responses.create({
           answer: answer,
           question: question,
-          string_value: value,
+          answer.value_key => value,
           response_group: i
         })
         i += 1

--- a/app/models/certification_campaign.rb
+++ b/app/models/certification_campaign.rb
@@ -1,4 +1,5 @@
 class CertificationCampaign < ActiveRecord::Base
+  include Ownership
   validates :name, uniqueness: true, presence: true
 
   has_many :certificate_generators

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,5 +1,6 @@
 class Claim < ActiveRecord::Base
   include AASM
+  include Ownership
 
   DELIVERY_ADMIN_OVERRIDE = true
 

--- a/app/models/concerns/badges.rb
+++ b/app/models/concerns/badges.rb
@@ -1,17 +1,19 @@
 module Badges
   extend ActiveSupport::Concern
 
-  def self.badge_file_for_level(level)
-    filename = case level
-                 when 'basic'
-                   'raw_level_badge.png'
-                 when 'raw', 'pilot', 'standard', 'exemplar'
-                   "#{level}_level_badge.png"
-                 else
-                   'no_level_badge.png'
-               end
+  module ClassMethods
+    def badge_file_for_level(level)
+      filename = case level
+      when 'basic'
+        'raw_level_badge.png'
+      when 'raw', 'pilot', 'standard', 'exemplar'
+        "#{level}_level_badge.png"
+      else
+        'no_level_badge.png'
+      end
 
-    File.open(File.join(Rails.root, 'app/assets/images/badges', filename))
+      File.open(File.join(Rails.root, 'app/assets/images/badges', filename))
+    end
   end
 
   def badge_file

--- a/app/models/concerns/counts.rb
+++ b/app/models/concerns/counts.rb
@@ -1,10 +1,6 @@
 module Counts
   extend ActiveSupport::Concern
 
-  def self.included(base)
-    base.extend(ClassMethods)
-  end
-
   module ClassMethods
 
     def counts

--- a/app/models/concerns/ownership.rb
+++ b/app/models/concerns/ownership.rb
@@ -1,0 +1,16 @@
+module Ownership
+  extend ActiveSupport::Concern
+
+  def owned_by?(account)
+    user.present? && user == account
+  end
+
+  def unowned?
+    user.nil?
+  end
+
+  def unowned_or_by?(account)
+    unowned? || owned_by?(account)
+  end
+
+end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -1,4 +1,5 @@
 class Dataset < ActiveRecord::Base
+  include Ownership
   belongs_to :user
 
   delegate :name, :email, :to => :user, :prefix => true, :allow_nil => true
@@ -113,21 +114,7 @@ class Dataset < ActiveRecord::Base
     response_set = newest_response_set
 
     if response_set.certificate_generator && response_set.certificate_generator.completed?
-      errors = []
-
-      response_set.responses_with_url_type.each do |response|
-        if response.error
-          errors.push("The question '#{response.question.reference_identifier}' must have a valid URL")
-        end
-      end
-
-      response_set.survey.questions.where(is_mandatory: true).each do |question|
-        response = response_set.responses.detect {|r| r.question_id == question.id}
-
-        if !response || response.empty?
-          errors.push("The question '#{question.reference_identifier}' is mandatory")
-        end
-      end
+      errors = response_set.response_errors
 
       certificate_url = certificate.url(format: :json) if certificate
 

--- a/app/models/dependency_condition.rb
+++ b/app/models/dependency_condition.rb
@@ -18,7 +18,7 @@ class DependencyCondition < ActiveRecord::Base
 
       responses_pre.select {|rs| rs[:answer_id] == answer_id} .each do |response|
       # response_set.responses.where(answer_id: answer).each do |response|
-        is_blank = false unless response.string_value.blank?
+        is_blank = false unless response.data_value.blank?
       end
 
       flip = operator == '!='

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -6,6 +6,7 @@ class Question < ActiveRecord::Base
 
   scope :excluding, lambda { |*objects| where(['questions.id NOT IN (?)', (objects.flatten.compact << 0)]) }
   scope :mandatory, where(is_mandatory: true)
+  scope :urls, joins(:answers).merge(Answer.urls)
 
   before_save :cache_question_or_answer_corresponding_to_requirement
   before_save :set_default_value_for_required

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -14,6 +14,13 @@ class Response < ActiveRecord::Base
 
   before_save :resolve_if_url
 
+  scope :filled, joins(:question).where(<<-SQL)
+    CASE questions.pick
+    WHEN 'none' THEN trim(string_value) != ''
+    ELSE answer_id is not null
+    END
+  SQL
+
   def sibling_responses(responses)
     (responses || []).select{|r| r.question_id == question_id && r.response_set_id == response_set_id}
   end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -431,11 +431,12 @@ class ResponseSet < ActiveRecord::Base
       next if value.nil? || question.nil?
 
       if question.type == :none || question.type == :repeater
+        answer = question.answers.first
         ui_hash.push(HashWithIndifferentAccess.new(
           question_id: question.id.to_s,
           api_id: response ? response.api_id : Surveyor::Common.generate_api_id,
-          answer_id: question.answers.first.id.to_s,
-          string_value: value,
+          answer_id: answer.id.to_s,
+          answer.value_key => value,
           autocompleted: true
         ))
       end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -3,6 +3,7 @@ require 'odibot'
 class ResponseSet < ActiveRecord::Base
   include Surveyor::Models::ResponseSetMethods
   include AASM
+  include Ownership
 
   # Surveyor field types
   VALUE_FIELDS = [:datetime_value, :integer_value, :float_value, :unit, :text_value, :string_value]
@@ -258,7 +259,7 @@ class ResponseSet < ActiveRecord::Base
   end
 
   def incomplete_triggered_mandatory_questions
-    responded_to_question_ids = responses.pluck('question_id')
+    responded_to_question_ids = responses.filled.pluck('question_id')
     triggered_mandatory_questions.reject { |q| responded_to_question_ids.include? q.id }
   end
 
@@ -316,7 +317,7 @@ class ResponseSet < ActiveRecord::Base
   end
 
   def responses_with_url_type
-    responses.joins(:answer).where({:answers => {input_type: 'url'}}).readonly(false)
+    responses.joins(:answer).merge(Answer.urls).readonly(false)
   end
 
   def all_urls_resolve?
@@ -461,6 +462,23 @@ class ResponseSet < ActiveRecord::Base
     end
 
     update_from_ui_hash(Hash[ui_hash.map.with_index { |value, i| [i.to_s, value] }])
+  end
+
+  def response_errors
+    errors = Hash.new { |h, k| h[k] = [] }
+    incomplete_triggered_mandatory_questions.each do |question|
+      response = responses.where(question_id: question.id).first
+
+      if !response || response.empty?
+        errors[question.reference_identifier] << 'mandatory'
+      end
+    end
+    responses_with_url_type.each do |response|
+      unless response.url_valid_or_explained?
+        errors[response.question.reference_identifier] << 'invalid-url'
+      end
+    end
+    errors
   end
 
   def assign_to_user!(user)

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -510,7 +510,7 @@ class ResponseSet < ActiveRecord::Base
     code = resolve_url(url)
 
     if code == 200
-      kitten_data = KittenData.create(url: url, response_set: self)
+      create_kitten_data(url: url)
       update_responses(kitten_data.fields)
     end
   end

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -36,22 +36,26 @@
       <td>
         <%= boolean_mark(generator.published?) %>
       </td>
-      <td>
-        <%= link_to generator.dataset.title, generator.dataset.documentation_url %>
-      </td>
-      <td>
-        <% if generator.published? %>
-          <%= link_to t("levels.#{generator.certificate.attained_level}.title"), dataset_certificate_path(generator.dataset, generator.certificate) %>
-        <% end %>
-      </td>
-      <td>
-        <% if can? :edit, generator.response_set %>
-          <%= link_to "edit", continue_path(generator.response_set) %>
-        <% end %>
-      </td>
-      <td>
-        <%= generator.dataset.user_email %>
-      </td>
+      <% if generator.completed? %>
+        <td>
+            <%= link_to generator.dataset.title, generator.dataset.documentation_url %>
+        </td>
+        <td>
+            <% if generator.published? %>
+            <%= link_to t("levels.#{generator.certificate.attained_level}.title"), dataset_certificate_path(generator.dataset, generator.certificate) %>
+            <% end %>
+        </td>
+        <td>
+            <% if can? :edit, generator.response_set %>
+            <%= link_to "edit", continue_path(generator.response_set) %>
+            <% end %>
+        </td>
+        <td>
+            <%= generator.dataset.user_email %>
+        </td>
+      <% else %>
+        <td colspan="4">Processing…</td>
+      <% end %>
     </tr>
   <% end %>
 </table>

--- a/app/views/datasets/index.json.jbuilder
+++ b/app/views/datasets/index.json.jbuilder
@@ -25,7 +25,7 @@ json.certificates do
       json.uri dataset_url(dataset, :protocol => embed_protocol)
       json.dataLicense dataset.certificate.response_set.data_licence_determined_from_responses[:url]
       json.contentLicense dataset.certificate.response_set.content_licence_determined_from_responses[:url]
-      json.documentationUrl dataset.certificate.response_set.documentation_url.string_value if dataset.certificate.response_set.documentation_url
+      json.documentationUrl dataset.certificate.response_set.documentation_url.data_value if dataset.certificate.response_set.documentation_url
     end
     json.level t("levels.#{dataset.certificate.attained_level}.title").downcase
     json.created_at dataset.certificate.created_at

--- a/app/views/partials/_answer.html.haml
+++ b/app/views/partials/_answer.html.haml
@@ -41,6 +41,10 @@
       - answer_attrs[:input_html][:placeholder] = a.placeholder_for(@render_context, I18n.locale) unless a.placeholder.blank?
       - answer_attrs[:input_html][:required] = 'required' if q.is_mandatory?
 
+      - if a.input_type == 'url'
+        - answer_attrs[:as] = :string
+        - answer_attrs[:input_html][:class] << 'string'
+
       = ff.input rc_to_attr(a.response_class), answer_attrs
     - else
       = a.text_for(nil, @render_context, I18n.locale)

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -48,28 +48,22 @@ end
 
 Given(/^my dataset contains contact details$/) do
   @email = "newuser@example.com"
-  ResponseSet.any_instance.stubs(:kitten_data).returns({data: {
-      publishers: [
-        DataKitten::Agent.new(mbox: @email)
-      ]
-    }})
+  ResponseSet.any_instance.stubs(:kitten_data).returns(stub(
+    :contacts_with_email => [DataKitten::Agent.new(mbox: @email)]
+  ))
 end
 
 Given(/^my dataset does not contain contact details$/) do
-  ResponseSet.any_instance.stubs(:kitten_data).returns({data: {
-      publishers: [
-        DataKitten::Agent.new(mbox: "")
-      ]
-    }})
+  ResponseSet.any_instance.stubs(:kitten_data).returns(stub(
+    :contacts_with_email => []
+  ))
   @email = @api_user.email
 end
 
 Given(/^my dataset contains invalid contact details$/) do
-  ResponseSet.any_instance.stubs(:kitten_data).returns({data: {
-      publishers: [
-        DataKitten::Agent.new(mbox: "bad email@example.org")
-      ]
-    }})
+  ResponseSet.any_instance.stubs(:kitten_data).returns(stub(
+    :contacts_with_email => [DataKitten::Agent.new(mbox: "bad email@example.org")]
+  ))
   @email = @api_user.email
 end
 

--- a/lib/odibot.rb
+++ b/lib/odibot.rb
@@ -12,7 +12,7 @@ class ODIBot
     ODIBot.handle_errors(0) do
       code = Rails.cache.fetch(@url) rescue nil
       if code.nil?
-        code = self.class.get(@url, @options).code
+        code = self.class.head(@url, @options).code
         Rails.cache.write(@url, code, expires_in: 5.minute)
       end
       code

--- a/lib/odibot.rb
+++ b/lib/odibot.rb
@@ -13,6 +13,7 @@ class ODIBot
       code = Rails.cache.fetch(@url) rescue nil
       if code.nil?
         code = self.class.head(@url, @options).code
+        code = self.class.get(@url, @options).code if code == 404
         Rails.cache.write(@url, code, expires_in: 5.minute)
       end
       code

--- a/prototype/surveyor.xsl
+++ b/prototype/surveyor.xsl
@@ -148,7 +148,14 @@
 <xsl:template match="input" mode="structure">
 	<xsl:element name="a_1">
 		<xsl:attribute name="label" select="@placeholder" />
-		<xsl:attribute name="type" select="'string'" />
+		<xsl:choose>
+		<xsl:when test="@type = 'url'">
+			<xsl:attribute name="type" select="'text'" />
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:attribute name="type" select="'string'" />
+		</xsl:otherwise>
+		</xsl:choose>
 		<xsl:apply-templates select="@*" mode="structure" />
 		<xsl:if test="..//requirement">
 			<xsl:attribute name="requirement" select="..//requirement/local:requirementId(.)" separator=", " />

--- a/surveys/odc_questionnaire.UK.rb
+++ b/surveys/odc_questionnaire.UK.rb
@@ -24,7 +24,7 @@ survey 'GB',
       :text_as_statement => 'This data is described at',
       :help_text => 'Give a URL for people to read about the contents of your open data and find more detail. It can be a page within a bigger catalog like data.gov.uk.'
     a_1 'Documentation URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Documentation URL',
       :requirement => ['pilot_1', 'basic_1']
@@ -60,7 +60,7 @@ survey 'GB',
       :text_as_statement => 'The data is published on',
       :help_text => 'Give a URL to a website, this helps us to group data from the same organisation even if people give different names.'
     a_1 'Publisher URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Publisher URL'
 
@@ -118,7 +118,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_publisherRights, '==', :a_complicated
     a_1 'Risk Documentation URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Risk Documentation URL',
       :requirement => ['pilot_2']
@@ -243,7 +243,7 @@ survey 'GB',
     condition_C :q_crowdsourced, '==', :a_true
     condition_D :q_crowdsourcedContent, '==', :a_true
     a_1 'Contributor Licence Agreement URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Contributor Licence Agreement URL',
       :required => :required
@@ -280,7 +280,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_publisherOrigin, '==', :a_false
     a_1 'Data Sources Documentation URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Data Sources Documentation URL',
       :requirement => ['pilot_3']
@@ -325,7 +325,7 @@ survey 'GB',
       :text_as_statement => 'The rights statement is at',
       :help_text => 'Give the URL to a page that describes the right to re-use this dataset. This should include a reference to its license, attribution requirements, and a statement about relevant copyright and database rights. A rights statement helps people understand what they can and can\'t do with the data.'
     a_1 'Rights Statement URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Rights Statement URL',
       :requirement => ['pilot_4']
@@ -410,7 +410,7 @@ survey 'GB',
     condition_B :q_dataNotApplicable, '==', :a_waived
     condition_C :q_dataWaiver, '==', :a_other
     a_1 'Waiver URL',
-      :string,
+      :text,
       :input_type => :url,
       :required => :required,
       :placeholder => 'Waiver URL'
@@ -437,7 +437,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_dataLicence, '==', :a_other
     a_1 'Other Licence URL',
-      :string,
+      :text,
       :input_type => :url,
       :required => :required,
       :placeholder => 'Other Licence URL'
@@ -569,7 +569,7 @@ survey 'GB',
     condition_C :q_contentNotApplicable, '==', :a_waived
     condition_D :q_contentWaiver, '==', :a_other
     a_1 'Waiver URL',
-      :string,
+      :text,
       :input_type => :url,
       :required => :required,
       :placeholder => 'Waiver URL'
@@ -598,7 +598,7 @@ survey 'GB',
     condition_A :q_contentRights, '==', :a_samerights
     condition_B :q_contentLicence, '==', :a_other
     a_1 'Licence URL',
-      :string,
+      :text,
       :input_type => :url,
       :required => :required,
       :placeholder => 'Licence URL'
@@ -633,7 +633,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_contentRights, '==', :a_mixedrights
     a_1 'Content Rights Description URL',
-      :string,
+      :text,
       :input_type => :url,
       :required => :required,
       :placeholder => 'Content Rights Description URL'
@@ -825,7 +825,7 @@ survey 'GB',
     condition_B :q_appliedAnon, '==', :a_false
     condition_C :q_lawfulDisclosure, '==', :a_true
     a_1 'Disclosure Rationale URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Disclosure Rationale URL',
       :requirement => ['standard_9']
@@ -877,7 +877,7 @@ survey 'GB',
     condition_C :q_lawfulDisclosure, '==', :a_true
     condition_D :q_privacyImpactAssessmentExists, '==', :a_true
     a_1 'Privacy Impact Assessment URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Privacy Impact Assessment URL',
       :requirement => ['standard_10']
@@ -927,13 +927,14 @@ survey 'GB',
       :text_as_statement => 'Individuals affected by this data have this privacy notice',
       :help_text => 'When you collect data about individuals you must tell them how that data will be used. People who use your data need this to make sure they comply with the Data Protection Act.',
       :help_text_more_url => 'http://www.ico.org.uk/for_organisations/data_protection/the_guide/principle_2'
-    dependency :rule => 'A and (B or C) and D'
+    dependency :rule => 'A and (B or C) and D and E'
     condition_A :q_dataPersonal, '==', :a_individual
     condition_B :q_appliedAnon, '==', :a_true
     condition_C :q_lawfulDisclosure, '==', :a_true
     condition_D :q_privacyImpactAssessmentExists, '==', :a_true
+    condition_E :q_lawfulDisclosure, '!=', :a_true
     a_1 'Privacy Notice URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Privacy Notice URL',
       :requirement => ['pilot_7']
@@ -941,12 +942,13 @@ survey 'GB',
     label_pilot_7 'You should <strong>tell people what purposes the individuals in your data consented to you using their data for</strong>. So that they use your data for the same purposes and comply with the Data Protection Act.',
       :custom_renderer => '/partials/requirement_pilot',
       :requirement => 'pilot_7'
-    dependency :rule => 'A and (B or C) and D and E'
+    dependency :rule => 'A and (B or C) and D and E and F'
     condition_A :q_dataPersonal, '==', :a_individual
     condition_B :q_appliedAnon, '==', :a_true
     condition_C :q_lawfulDisclosure, '==', :a_true
     condition_D :q_privacyImpactAssessmentExists, '==', :a_true
-    condition_E :q_individualConsentURL, '==', {:string_value => '', :answer_reference => '1'}
+    condition_E :q_lawfulDisclosure, '!=', :a_true
+    condition_F :q_individualConsentURL, '==', {:string_value => '', :answer_reference => '1'}
 
     q_dpStaff 'Is there someone in your organisation who is responsible for data protection?',
       :discussion_topic => :gb_dpStaff,
@@ -1051,7 +1053,7 @@ survey 'GB',
       dependency :rule => 'A'
       condition_A :q_onWebsite, '==', :a_true
       a_1 'Web page URL',
-        :string,
+        :text,
         :input_type => :url,
         :required => :required,
         :placeholder => 'Web page URL'
@@ -1085,7 +1087,7 @@ survey 'GB',
       dependency :rule => 'A'
       condition_A :q_listed, '==', :a_true
       a_1 'Listing URL',
-        :string,
+        :text,
         :input_type => :url,
         :required => :required,
         :placeholder => 'Listing URL'
@@ -1119,7 +1121,7 @@ survey 'GB',
       dependency :rule => 'A'
       condition_A :q_referenced, '==', :a_true
       a_1 'Reference URL',
-        :string,
+        :text,
         :input_type => :url,
         :required => :required,
         :placeholder => 'Reference URL'
@@ -1444,7 +1446,7 @@ survey 'GB',
       :text_as_statement => 'Data quality is documented at',
       :help_text => 'Give a URL where people can find out about the quality of your data. People accept that errors are inevitable, from equipment malfunctions or mistakes that happen in system migrations. You should be open about quality so people can judge how much to rely on this data.'
     a_1 'Data Quality Documentation URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Data Quality Documentation URL',
       :requirement => ['standard_22']
@@ -1461,7 +1463,7 @@ survey 'GB',
       :text_as_statement => 'Quality control processes are described at',
       :help_text => 'Give a URL for people to learn about ongoing checks on your data, either automatic or manual. This reassures them that you take quality seriously and encourages improvements that benefit everyone.'
     a_1 'Quality Control Process Description URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Quality Control Process Description URL',
       :requirement => ['exemplar_10']
@@ -1502,7 +1504,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_service
     a_1 'Service Availability Documentation URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Service Availability Documentation URL',
       :requirement => ['standard_24']
@@ -1522,7 +1524,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_service
     a_1 'Service Status URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Service Status URL',
       :requirement => ['exemplar_11']
@@ -1589,7 +1591,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_oneoff
     a_1 'Dataset URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Dataset URL',
       :requirement => ['basic_9', 'pilot_14']
@@ -1667,7 +1669,7 @@ survey 'GB',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '==', :a_current
     a_1 'Current Dataset URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Current Dataset URL',
       :required => :required
@@ -1697,7 +1699,7 @@ survey 'GB',
     condition_A :q_releaseType, '==', :a_series
     condition_B :q_versionManagement, '==', :a_list
     a_1 'Version List URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Version List URL',
       :required => :required
@@ -1710,7 +1712,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_releaseType, '==', :a_service
     a_1 'Endpoint URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Endpoint URL',
       :requirement => ['basic_11', 'standard_28']
@@ -1782,7 +1784,7 @@ survey 'GB',
     condition_B :q_provideDumps, '==', :a_true
     condition_C :q_dumpManagement, '==', :a_current
     a_1 'Current Dump URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Current Dump URL',
       :required => :required
@@ -1814,7 +1816,7 @@ survey 'GB',
     condition_B :q_provideDumps, '==', :a_true
     condition_C :q_dumpManagement, '==', :a_list
     a_1 'Dump List URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Dump List URL',
       :required => :required
@@ -1828,7 +1830,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_changeFeed, '==', :a_true
     a_1 'Change Feed URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Change Feed URL',
       :required => :required
@@ -2083,7 +2085,7 @@ survey 'GB',
     condition_A :q_identifiers, '==', :a_true
     condition_B :q_resolvingIds, '==', :a_service
     a_1 'Identifier Resolution Service URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Identifier Resolution Service URL',
       :requirement => ['standard_35']
@@ -2171,7 +2173,7 @@ survey 'GB',
       :text_as_statement => 'This data can be verified using',
       :help_text => 'If you deliver important data to people they should be able to check that what they receive is the same as what you published. For example, you can digitally sign the data you publish, so people can tell if it has been tampered with.'
     a_1 'Verification Process URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Verification Process URL',
       :requirement => ['exemplar_20']
@@ -2409,7 +2411,7 @@ survey 'GB',
       :display_on_certificate => true,
       :text_as_statement => 'The technical documentation for the data is at'
     a_1 'Technical Documentation URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Technical Documentation URL',
       :requirement => ['pilot_21']
@@ -2435,7 +2437,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_vocabulary, '==', :a_true
     a_1 'Schema Documentation URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Schema Documentation URL',
       :requirement => ['standard_54']
@@ -2462,7 +2464,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_codelists, '==', :a_true
     a_1 'Codelist Documentation URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Codelist Documentation URL',
       :requirement => ['standard_55']
@@ -2484,7 +2486,7 @@ survey 'GB',
       :text_as_statement => 'Find out how to contact someone about this data at',
       :help_text => 'Give a URL for a page that describes how people can contact someone if they have questions about the data.'
     a_1 'Contact Documentation',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Contact Documentation',
       :requirement => ['pilot_22']
@@ -2500,7 +2502,7 @@ survey 'GB',
       :display_on_certificate => true,
       :text_as_statement => 'Find out how to suggest improvements to publication at'
     a_1 'Improvement Suggestions URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Improvement Suggestions URL',
       :requirement => ['pilot_23']
@@ -2516,7 +2518,7 @@ survey 'GB',
       :display_on_certificate => true,
       :text_as_statement => 'Find out where to send questions about privacy at'
     a_1 'Confidentiality Contact Documentation',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Confidentiality Contact Documentation',
       :requirement => ['pilot_24']
@@ -2553,7 +2555,7 @@ survey 'GB',
       dependency :rule => 'A'
       condition_A :q_socialMedia, '==', :a_true
       a_1 'Social Media URL',
-        :string,
+        :text,
         :input_type => :url,
         :required => :required,
         :placeholder => 'Social Media URL'
@@ -2566,7 +2568,7 @@ survey 'GB',
       :text_as_statement => 'Discuss this data at',
       :help_text => 'Give a URL to your forum or mailing list where people can talk about your data.'
     a_1 'Forum or Mailing List URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Forum or Mailing List URL',
       :requirement => ['standard_57']
@@ -2585,7 +2587,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_corrected, '==', :a_true
     a_1 'Correction Instructions URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Correction Instructions URL',
       :requirement => ['standard_58']
@@ -2605,7 +2607,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_corrected, '==', :a_true
     a_1 'Correction Notification URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Correction Notification URL',
       :requirement => ['standard_59']
@@ -2640,7 +2642,7 @@ survey 'GB',
     dependency :rule => 'A'
     condition_A :q_engagementTeam, '==', :a_true
     a_1 'Community Engagement Team Home Page URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Community Engagement Team Home Page URL',
       :required => :required
@@ -2655,7 +2657,7 @@ survey 'GB',
       :text_as_statement => 'Tools to help use this data are listed at',
       :help_text => 'Give a URL that lists the tools you know or recommend people can use when they work with your data.'
     a_1 'Tool URL',
-      :string,
+      :text,
       :input_type => :url,
       :placeholder => 'Tool URL',
       :requirement => ['exemplar_22']

--- a/test/unit/certificate_generator_test.rb
+++ b/test/unit/certificate_generator_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class CertificateGeneratorTest < ActiveSupport::TestCase
 
   def setup
+    stub_request(:head, "http://www.example.com/error").to_return(status: 200)
     load_custom_survey 'cert_generator.rb'
     @user = FactoryGirl.create :user
   end
@@ -65,13 +66,13 @@ class CertificateGeneratorTest < ActiveSupport::TestCase
   end
 
   test "creating certificate with invalid URL" do
-    stub_request(:get, "http://www.example/error").
-                to_return(:body => "", status: 404)
+    stub_request(:head, "http://www.example.com/error").
+                to_return(status: 404)
 
     dataset = {
       dataTitle: 'The title',
       releaseType: 'oneoff',
-      publisherUrl: 'http://www.example/error',
+      publisherUrl: 'http://www.example.com/error',
       publisherRights: 'yes',
       publisherOrigin: 'true',
       linkedTo: 'true',
@@ -190,5 +191,98 @@ class CertificateGeneratorTest < ActiveSupport::TestCase
         assert_equal({'favouriteAnimal' => ['mandatory']}, response[:errors])
       end
     end
+
+  test "determining contact email for dataset creates new user from publisher contact email" do
+    generator = CertificateGenerator.create(request: {}, user: @user)
+    response_set = generator.build_response_set
+    response_set.kitten_data = kd = KittenData.new
+    kd[:data][:publishers] = [DataKitten::Agent.new(mbox: 'test@datapub.org')]
+    kd[:data][:maintainers] = [DataKitten::Agent.new(mbox: 'wrong@datapub.org')]
+    kd[:data][:contributors] = [DataKitten::Agent.new(mbox: 'wrong@datapub.org')]
+
+    user = generator.determine_user(response_set, true)
+
+    assert user.persisted?
+    assert_equal 'test@datapub.org', user.email
+  end
+
+  test "determining contact email for dataset finds user from publisher contact email" do
+    existing_user = FactoryGirl.create(:user, email: 'test@datapub.org')
+    generator = CertificateGenerator.create(request: {}, user: @user)
+    response_set = generator.build_response_set
+    response_set.kitten_data = kd = KittenData.new
+    kd[:data][:publishers] = [DataKitten::Agent.new(mbox: 'test@datapub.org')]
+    kd[:data][:maintainers] = [DataKitten::Agent.new(mbox: 'wrong@datapub.org')]
+    kd[:data][:contributors] = [DataKitten::Agent.new(mbox: 'wrong@datapub.org')]
+
+    found_user = generator.determine_user(response_set, true)
+
+    assert_equal existing_user, found_user
+  end
+
+  test "determing contact email uses maintainer if no publisher present" do
+    generator = CertificateGenerator.create(request: {}, user: @user)
+    response_set = generator.build_response_set
+    response_set.kitten_data = kd = KittenData.new
+    kd[:data][:publishers] = []
+    kd[:data][:maintainers] = [DataKitten::Agent.new(mbox: 'test@datapub.org')]
+    kd[:data][:contributors] = [DataKitten::Agent.new(mbox: 'wrong@datapub.org')]
+
+    user = generator.determine_user(response_set, true)
+
+    assert user.persisted?
+    assert_equal 'test@datapub.org', user.email
+  end
+
+  test "determing contact email uses contributor if no publisher present" do
+    generator = CertificateGenerator.create(request: {}, user: @user)
+    response_set = generator.build_response_set
+    response_set.kitten_data = kd = KittenData.new
+    kd[:data][:publishers] = []
+    kd[:data][:maintainers] = nil
+    kd[:data][:contributors] = [
+      DataKitten::Agent.new(mbox: ''),
+      DataKitten::Agent.new(mbox: 'test@datapub.org')
+    ]
+
+    user = generator.determine_user(response_set, true)
+
+    assert user.persisted?
+    assert_equal 'test@datapub.org', user.email
+  end
+
+  test "finds first existant user before trying to create an owner" do
+    existing_user = FactoryGirl.create(:user, email: 'present@datapub.org')
+    generator = CertificateGenerator.create(request: {}, user: @user)
+    response_set = generator.build_response_set
+    response_set.kitten_data = kd = KittenData.new
+    kd[:data][:publishers] = [DataKitten::Agent.new(mbox: 'test@datapub.org')]
+    kd[:data][:maintainers] = [DataKitten::Agent.new(mbox: 'present@datapub.org')]
+    kd[:data][:contributors] = [DataKitten::Agent.new(mbox: 'wrong@datapub.org')]
+
+    found_user = generator.determine_user(response_set, true)
+
+    assert_equal existing_user, found_user
+  end
+
+  test "does not create user if create is false" do
+    generator = CertificateGenerator.create(request: {}, user: @user)
+    response_set = generator.build_response_set
+    response_set.kitten_data = kd = KittenData.new
+    kd[:data][:publishers] = []
+    kd[:data][:maintainers] = nil
+    kd[:data][:contributors] = [DataKitten::Agent.new(mbox: 'test@datapub.org')]
+
+    user = generator.determine_user(response_set, false)
+
+    assert_equal user, @user
+  end
+
+  test "creating a user when already exists" do
+    existing_user = FactoryGirl.create(:user, email: 'present@datapub.org')
+    generator = CertificateGenerator.create(request: {}, user: @user)
+    user = generator.create_user_from_contact(DataKitten::Agent.new(mbox: 'present@datapub.org'))
+    assert_equal existing_user, user
+  end
 
 end

--- a/test/unit/certificate_generator_test.rb
+++ b/test/unit/certificate_generator_test.rb
@@ -112,7 +112,7 @@ class CertificateGeneratorTest < ActiveSupport::TestCase
       response = CertificateGenerator.update(Dataset.last, update, 'cert-generator', @user)
       assert_equal(true, response[:success])
       assert_equal(true, response[:published])
-      assert_equal([], response[:errors])
+      assert_equal({}, response[:errors])
     end
   end
 
@@ -147,14 +147,14 @@ class CertificateGeneratorTest < ActiveSupport::TestCase
       response = CertificateGenerator.update(Dataset.last, update, 'cert-generator', @user)
       assert_equal(true, response[:success])
       assert_equal(false, response[:published])
-      assert_equal(["The question 'publisherUrl' is mandatory"], response[:errors])
+      assert_equal({'publisherUrl' => ['mandatory']}, response[:errors])
     end
 
     assert_no_difference 'ResponseSet.count' do
       response = CertificateGenerator.update(Dataset.last, update, 'cert-generator', @user)
       assert_equal(true, response[:success])
       assert_equal(false, response[:published])
-      assert_equal(["The question 'publisherUrl' is mandatory"], response[:errors])
+      assert_equal({'publisherUrl' => ['mandatory']}, response[:errors])
     end
   end
 
@@ -187,7 +187,7 @@ class CertificateGeneratorTest < ActiveSupport::TestCase
         response = CertificateGenerator.update(Dataset.last, update, 'cert-generator', @user)
         assert_equal(true, response[:success])
         assert_equal(false, response[:published])
-        assert_equal(["The question 'favouriteAnimal' is mandatory"], response[:errors])
+        assert_equal({'favouriteAnimal' => ['mandatory']}, response[:errors])
       end
     end
 

--- a/test/unit/dataset_test.rb
+++ b/test/unit/dataset_test.rb
@@ -144,7 +144,7 @@ class DatasetTest < ActiveSupport::TestCase
     assert_equal(true, response[:success])
     assert_equal(true, response[:published])
     assert_equal(user.email, response[:owner_email])
-    assert_equal([], response[:errors])
+    assert_equal({}, response[:errors])
   end
 
   test 'get results of certificate with missing field' do
@@ -165,7 +165,7 @@ class DatasetTest < ActiveSupport::TestCase
 
     assert_equal(true, response[:success])
     assert_equal(false, response[:published])
-    assert_equal(["The question 'dataTitle' is mandatory"], response[:errors])
+    assert_equal({'dataTitle' => ['mandatory']}, response[:errors])
   end
 
   test 'get results of certificate with invalid URL' do
@@ -190,7 +190,7 @@ class DatasetTest < ActiveSupport::TestCase
 
     assert_equal(true, response[:success])
     assert_equal(false, response[:published])
-    assert_equal(["The question 'publisherUrl' must have a valid URL"], response[:errors])
+    assert_equal({'publisherUrl' => ['invalid-url']}, response[:errors])
   end
 
   test "doesn't show results when generation hasn't happened" do
@@ -213,7 +213,7 @@ class DatasetTest < ActiveSupport::TestCase
     assert_equal(true, response[:success])
     assert_equal(true, response[:published])
     assert_equal(user.email, response[:owner_email])
-    assert_equal([], response[:errors])
+    assert_equal({}, response[:errors])
   end
 
   test "generation result for unclaimed certificate" do
@@ -235,7 +235,7 @@ class DatasetTest < ActiveSupport::TestCase
     assert_equal(true, response[:success])
     assert_equal(true, response[:published])
     assert_equal(nil, response[:owner_email])
-    assert_equal([], response[:errors])
+    assert_equal({}, response[:errors])
   end
 
   test 'returns an api_url' do

--- a/test/unit/dataset_test.rb
+++ b/test/unit/dataset_test.rb
@@ -172,13 +172,13 @@ class DatasetTest < ActiveSupport::TestCase
     load_custom_survey 'cert_generator.rb'
     user = FactoryGirl.create :user
 
-    stub_request(:get, "http://www.example/error").
-        to_return(:body => "", status: 404)
+    stub_request(:head, "http://www.example.com/error").
+        to_return(status: 404)
 
     request = {
       dataTitle: 'The title',
       releaseType: 'oneoff',
-      publisherUrl: 'http://www.example/error',
+      publisherUrl: 'http://www.example.com/error',
       publisherRights: 'yes',
       publisherOrigin: 'true',
       linkedTo: 'true',

--- a/test/unit/kitten_data_test.rb
+++ b/test/unit/kitten_data_test.rb
@@ -94,6 +94,7 @@ class KittenDataTest < ActiveSupport::TestCase
   end
 
   def setup
+    stub_request(:get, "http://www.example.com").to_return(status: 200)
     set_normal_data
     @kitten_data = nil
   end
@@ -234,6 +235,7 @@ class KittenDataTest < ActiveSupport::TestCase
   end
 
   test 'data.gov.uk assumptions are applied' do
+    stub_request(:get, 'http://data.gov.uk/some_crazy_data').to_return(status: 200)
     @kitten_data = KittenData.new(url: 'http://data.gov.uk/some_crazy_data')
 
     assert_equal "true", kitten_data.fields["publisherOrigin"]
@@ -241,7 +243,7 @@ class KittenDataTest < ActiveSupport::TestCase
     assert_equal "false", kitten_data.fields["frequentChanges"]
     assert_equal "false", kitten_data.fields["vocabulary"]
     assert_equal "false", kitten_data.fields["codelists"]
-    assert_equal kitten_data.url, @kitten_data.fields["copyrightURL"]
+    assert_equal kitten_data.url, kitten_data.fields["copyrightURL"]
     assert_equal "true", kitten_data.fields["listed"]
     assert_equal "http://data.gov.uk", kitten_data.fields["listing"]
     assert_equal "samerights", kitten_data.fields["contentRights"]

--- a/test/unit/odibot_test.rb
+++ b/test/unit/odibot_test.rb
@@ -70,6 +70,15 @@ class ODIBotTest < ActiveSupport::TestCase
     assert ODIBot.new("http://www.example.com").valid?
   end
 
+  test "validates url by checking if get response if head is not found" do
+    # CKAN API behaves badly and 404s HEAD requests when GET returns a response
+    stub_request(:head, "http://www.example.com").
+                to_return(:body => "", status: 404)
+    stub_request(:get, "http://www.example.com").
+                to_return(:body => "", status: 200)
+    assert ODIBot.new("http://www.example.com").valid?
+  end
+
   test "checks if url is http before fetching" do
     ODIBot.expects(:head).never
     refute ODIBot.new("foo bar").valid?

--- a/test/unit/odibot_test.rb
+++ b/test/unit/odibot_test.rb
@@ -8,7 +8,7 @@ class ODIBotTest < ActiveSupport::TestCase
   end
 
   test "Should return correct response code for 200" do
-    stub_request(:get, "http://www.example.com").
+    stub_request(:head, "http://www.example.com").
                 to_return(:body => "", status: 200)
 
     bot = ODIBot.new("http://www.example.com")
@@ -17,7 +17,7 @@ class ODIBotTest < ActiveSupport::TestCase
   end
 
   test "Should return correct response code for 500" do
-    stub_request(:get, "http://www.example.com").
+    stub_request(:head, "http://www.example.com").
                 to_return(:body => "", status: 500)
 
     bot = ODIBot.new("http://www.example.com")
@@ -26,7 +26,7 @@ class ODIBotTest < ActiveSupport::TestCase
   end
 
   test "Should cache responses" do
-    stub_request(:get, "http://www.example.com").
+    stub_request(:head, "http://www.example.com").
                 to_return(:body => "", status: 200)
 
     ODIBot.new("http://www.example.com").response_code
@@ -39,7 +39,7 @@ class ODIBotTest < ActiveSupport::TestCase
 
     bot = ODIBot.new("http://www.example.com")
 
-    ODIBot.expects(:get).never
+    ODIBot.expects(:head).never
 
     assert_equal 200, bot.response_code
   end
@@ -65,18 +65,18 @@ class ODIBotTest < ActiveSupport::TestCase
   end
 
   test "validates url by checking if http response is ok" do
-    stub_request(:get, "http://www.example.com").
+    stub_request(:head, "http://www.example.com").
                 to_return(:body => "", status: 200)
     assert ODIBot.new("http://www.example.com").valid?
   end
 
   test "checks if url is http before fetching" do
-    ODIBot.expects(:get).never
+    ODIBot.expects(:head).never
     refute ODIBot.new("foo bar").valid?
   end
 
   test "checks if url is specified enough to request" do
-    ODIBot.expects(:get).never
+    ODIBot.expects(:head).never
     refute ODIBot.new("http://").valid?
     refute ODIBot.new("http:///").valid?
     refute ODIBot.new("http://notadomain").valid?
@@ -87,7 +87,7 @@ class ODIBotTest < ActiveSupport::TestCase
       %w[/ page/subpage].each do |path|
         url = "#{scheme}://#{hostname}#{path}"
         test "skips http checks if url is #{url}" do
-          ODIBot.expects(:get).never
+          ODIBot.expects(:head).never
           assert ODIBot.new(url).valid?
         end
       end
@@ -96,7 +96,7 @@ class ODIBotTest < ActiveSupport::TestCase
 
   [SocketError, Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, OpenSSL::SSL::SSLError, Timeout::Error].each do |error|
     test "handles #{error.name}" do
-      stub_request(:get, "http://www.example.com").to_raise(error)
+      stub_request(:head, "http://www.example.com").to_raise(error)
       refute ODIBot.new("http://www.example.com").valid?
     end
   end


### PR DESCRIPTION
  - extract more licensing information from datasets
  - make the certificate generation api a little bit more machine readable
  - render certification campaign page while in progress
  - check urls with HEAD first instead of downloading data
  - allow url fields to be longer than 255 chars