### PR TITLE
Cope with absence of kitten data

### DIFF
--- a/app/models/kitten_data.rb
+++ b/app/models/kitten_data.rb
@@ -68,8 +68,12 @@ class KittenData < ActiveRecord::Base
     agents.select { |contact| contact.mbox.present? }
   end
 
+  def has_data?
+    data.present?
+  end
+
   def get(field)
-    data[field].presence if data
+    data[field].presence if has_data?
   end
 
   def get_list(field)

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -516,6 +516,10 @@ class ResponseSet < ActiveRecord::Base
     end
   end
 
+  def has_kitten_data?
+    kitten_data && kitten_data.has_data?
+  end
+
   def resolve_url(url)
     if url =~ /^#{URI::regexp}$/
       ODIBot.new(url).response_code rescue nil

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -520,6 +520,10 @@ class ResponseSet < ActiveRecord::Base
     kitten_data && kitten_data.has_data?
   end
 
+  def description
+    kitten_data.get(:description) if has_kitten_data?
+  end
+
   def resolve_url(url)
     if url =~ /^#{URI::regexp}$/
       ODIBot.new(url).response_code rescue nil

--- a/app/views/response_sets/_response_set.html.haml
+++ b/app/views/response_sets/_response_set.html.haml
@@ -1,8 +1,8 @@
 %div.certificate-data
-  - if response_set.kitten_data && response_set.kitten_data.get(:description).present?
+  - if description = response_set.description
     %hr.heavy
     %h3= t 'certificate.description'
-    %p.description= strip_tags response_set.kitten_data.get(:description)
+    %p.description= strip_tags description
 
   - response_set.survey.sections.each do |section|
     - questions = section.questions_for_certificate response_set

--- a/app/views/shared/_response_set_description.html.haml
+++ b/app/views/shared/_response_set_description.html.haml
@@ -1,6 +1,4 @@
-- description = response_set.kitten_data.data[:description] rescue nil
-
-- if description
+- if description = response_set.description
 
   -if defined?(leading_hr) && leading_hr
     %hr.heavy

--- a/app/views/shared/_response_set_summary.html.haml
+++ b/app/views/shared/_response_set_summary.html.haml
@@ -1,5 +1,3 @@
-- kitten_data = response_set.kitten_data
-
 .summary-data
   %h3= t :summary, scope: :summary_data
   %dl
@@ -14,7 +12,8 @@
 
     =detail_item(t :verification, scope: :summary_data) { t response_set.certificate.certification_type, scope: 'certificate.certification_types' }
 
-    - if kitten_data
+    - if response_set.has_kitten_data?
+      - kitten_data = response_set.kitten_data
       - [:release_date, :modified_date, :update_frequency, :publishers, :keywords].each do |key|
         = kitten_field(kitten_data, key)
 

--- a/test/functional/certificates_controller_test.rb
+++ b/test/functional/certificates_controller_test.rb
@@ -9,6 +9,14 @@ class CertificatesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "published certificates with legacy empty kitten_data can be shown" do
+    cert = FactoryGirl.create(:published_certificate_with_dataset)
+    cert.response_set.create_kitten_data
+    KittenData.any_instance.stubs(:data).returns(false)
+    get :show, {dataset_id: cert.dataset.id, id: cert.id}
+    assert_response :success
+  end
+
   test "unpublished certificates can't be shown" do
     cert = FactoryGirl.create(:certificate_with_dataset)
     get :show, {dataset_id: cert.dataset.id, id: cert.id}


### PR DESCRIPTION
in previous versions the data hash was serialised as `false` instead of `{}`

  - check for presence before attempting to access values
  - delegate access to description field to reduce need for checks in multiple places