### PR TITLE
Deploy 2015-05-08

### DIFF
--- a/app/models/concerns/badges.rb
+++ b/app/models/concerns/badges.rb
@@ -1,23 +1,21 @@
 module Badges
   extend ActiveSupport::Concern
 
-  module ClassMethods
-    def badge_file_for_level(level)
-      filename = case level
-      when 'basic'
-        'raw_level_badge.png'
-      when 'raw', 'pilot', 'standard', 'exemplar'
-        "#{level}_level_badge.png"
-      else
-        'no_level_badge.png'
-      end
-
-      File.open(File.join(Rails.root, 'app/assets/images/badges', filename))
+  def badge_file_for_level(level)
+    filename = case level
+    when 'basic'
+      'raw_level_badge.png'
+    when 'raw', 'pilot', 'standard', 'exemplar'
+      "#{level}_level_badge.png"
+    else
+      'no_level_badge.png'
     end
+
+    File.open(File.join(Rails.root, 'app/assets/images/badges', filename))
   end
 
   def badge_file
-    Certificate::Badges.badge_file_for_level(attained_level)
+    badge_file_for_level(attained_level)
   end
 
   def badge_url

--- a/app/models/kitten_data.rb
+++ b/app/models/kitten_data.rb
@@ -69,7 +69,7 @@ class KittenData < ActiveRecord::Base
   end
 
   def get(field)
-    data[field].presence
+    data[field].presence if data
   end
 
   def get_list(field)

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -80,7 +80,7 @@ class Response < ActiveRecord::Base
   end
 
   def autocompletable?
-    !!(auto_value && !auto_value.empty?)
+    auto_value.present?
   end
 
   def any_metadata_missing(responses)

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -436,7 +436,7 @@ class ResponseSet < ActiveRecord::Base
           question_id: question.id.to_s,
           api_id: response ? response.api_id : Surveyor::Common.generate_api_id,
           answer_id: answer.id.to_s,
-          answer.value_key => value,
+          answer.value_key => value.to_s,
           autocompleted: true
         ))
       end

--- a/test/functional/certificates_controller_test.rb
+++ b/test/functional/certificates_controller_test.rb
@@ -126,6 +126,13 @@ class CertificatesControllerTest < ActionController::TestCase
     assert_match /https:\/\//, json["certificate"]["dataset"]["uri"]
   end
 
+  test "requesting the png badge image" do
+    cert = FactoryGirl.create(:published_certificate_with_dataset)
+    get :badge, {dataset_id: cert.dataset.id, id: cert.id, format: "png"}
+
+    assert_equal File.read(File.join(Rails.root, 'app/assets/images/badges/raw_level_badge.png')), response.body
+  end
+
   test "mark certificate as valid" do
     cert = FactoryGirl.create(:certificate_with_dataset)
     user = FactoryGirl.create(:user)

--- a/test/unit/kitten_data_test.rb
+++ b/test/unit/kitten_data_test.rb
@@ -281,6 +281,12 @@ class KittenDataTest < ActiveSupport::TestCase
     assert_equal nil, kitten_data.fields["documentationMetadata"]
   end
 
+  test "accessor to data attributes returns nil on non serialzed kitten data" do
+    kd = KittenData.new
+    kd.data = false
+    assert_equal nil, kd.get(:title)
+  end
+
   test "accessor to data attributes" do
     kd = KittenData.new
     kd.data = {


### PR DESCRIPTION
  - When manually certifying a certificate store urls correctly (they were being serialised as URI objects)
  - More fixes for old blank kitten data objects