### PR TITLE
Fix progress panel

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -308,9 +308,19 @@ $(document).ready(function($){
     .then(function(data){
       $(panel).removeClass('loading');
 
+      var show_bar = data.attained == 'none'
+
       var levels = ['basic', 'pilot', 'standard', 'exemplar'];
       $.each(levels, function(idx, level) {
-          $('#bar-' + level).width(data[level] + '%');
+          var bar = $('#bar-' + level);
+          if (show_bar) {
+            bar.width(data[level] + '%');
+            bar.parent('.progress').show();
+            show_bar = false;
+          } else {
+            bar.parent('.progress').hide();
+            show_bar = data.attained == level;
+          }
       });
 
       $('#panel_handle')

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -2576,7 +2576,7 @@ header .save-button {
   position: absolute;
   right:0;
   width:280px;
-  padding:20px;
+  padding: 0 20px;
   height:100%;
   z-index:5;
 
@@ -2632,8 +2632,8 @@ header .save-button {
   }
 
   #panel_inner {
-    overflow-y: auto;
-    height: 75%;
+    overflow-y: scroll;
+    height: 80%;
   }
 
   #panel_loading{

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -11,6 +11,7 @@ class Response < ActiveRecord::Base
 
   after_save :set_default_dataset_title, :set_default_documentation_url
   after_save :update_survey_section_id
+  after_save :update_certificate_state
 
   before_save :resolve_if_url
 
@@ -154,6 +155,10 @@ class Response < ActiveRecord::Base
       survey_section_id = question.try(:survey_section_id)
       Response.update(id, :survey_section_id => survey_section_id) if survey_section_id
     end
+  end
+
+  def update_certificate_state
+    response_set.update_certificate
   end
 
 end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -301,7 +301,7 @@ class ResponseSet < ActiveRecord::Base
     entered = levels_count(entered_reference_identifiers)
 
     result = {
-      attained: certificate.attained_level
+      attained: attained_level
     }
     %w[basic pilot standard exemplar].each do |level|
       pending += outstanding[level] || 0

--- a/app/views/surveyor/_status_panel.html.haml
+++ b/app/views/surveyor/_status_panel.html.haml
@@ -5,6 +5,8 @@
     %p
       = t('status_panel.description')
       =link_to t('status_panel.about'), '/about'
+    %p
+      =link_to t('status_panel.improve_data'), surveyor.view_my_survey_requirements_path(:response_set_code => @response_set.access_code)
 
     %hr
     #panel_loading
@@ -42,6 +44,3 @@
     .progress.progress-striped.progress-danger
       .bar#bar-exemplar
 
-    %hr
-    %p
-      =link_to t('status_panel.improve_data'), surveyor.view_my_survey_requirements_path(:response_set_code => @response_set.access_code)


### PR DESCRIPTION
Certificate level now updates.

Made the panel a bit more usable by increasing used space and only showing the relevant progress bar.

Certificate Level now updates on responses instead of waiting for other bigger events