### PR TITLE
Fix rights statement display

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,11 @@ module ApplicationHelper
         value.name
       end
     when DataKitten::License
-      link_to(value.name, value.uri)
+      link_to(value.name, value.uri.to_s)
+    when DataKitten::Rights
+      if value.uri
+        link_to("Rights statement", value.uri.to_s)
+      end
     when DataKitten::Temporal
       dates = [kitten_value(value.start), kitten_value(value.end)].reject(&:blank?)
       safe_join(dates, ' — ') if dates.any?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,7 +33,7 @@ module ApplicationHelper
       link_to(value.name, value.uri.to_s)
     when DataKitten::Rights
       if value.uri
-        link_to("Rights statement", value.uri.to_s)
+        link_to(I18n.t('data_kitten.rights_statement'), value.uri.to_s)
       end
     when DataKitten::Temporal
       dates = [kitten_value(value.start), kitten_value(value.end)].reject(&:blank?)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,6 +282,7 @@ en:
     description: Description
     publishers: Publishers
     rights: Rights
+    rights_statement: Rights statement
     update_frequency: Update Frequency
     keywords: Keywords
     release_date: Release Date

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -89,4 +89,15 @@ class ApplicationHelperTest < ActionView::TestCase
 
     assert_equal '<a href="http://example.com/cc">CC</a>', kitten_value(license)
   end
+
+  test "kitten_value for rights" do
+    rights = DataKitten::Rights.new(uri: "http://example.com/rights")
+
+    assert_equal '<a href="http://example.com/rights">Rights statement</a>', kitten_value(rights)
+  end
+
+  test "kitten_value for blank rights object" do
+    blank_rights = DataKitten::Rights.new(uri: nil)
+    assert_equal nil, kitten_value(blank_rights)
+  end
 end


### PR DESCRIPTION
The `DataKitten::Rights` object wasn't being rendered as anything useful.

It is now a link to the rights statement.