### PR TITLE
Only hide help text when leaving the fieldset

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -196,7 +196,7 @@ $(document).ready(function($){
   });
 
   // Removes highlighting and information on mouseleave
-  $surveyElements.on('mouseleave', function(){
+  $surveyElements.filter('fieldset').on('mouseleave', function(){
     $($currentRow.data('metas')).hide();
     $($currentRow.data('input-metas')).hide();
 


### PR DESCRIPTION
Filter mouseleave event done to just fieldset.

This feature is still implement entirely in javascript though when most of it should just be CSS.