### PR TITLE
Fix editing with new survey

### DIFF
--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -1724,6 +1724,9 @@ a.transfer {
 .status-badge-archived{
   background-image:url(/assets/status/archived.png);
 }
+.status-badge-superceded{
+  background-image:url(/assets/status/archived.png);
+}
 
 .icon-exclamation-sign {
   &.expiring {

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -1456,10 +1456,13 @@ a.transfer {
     padding-right: 20px;
   }
 
-
-  // bit of a hack to get lines mid-gutter
   .row-fluid{
-    position: relative
+    position: relative;
+
+    .baseline {
+      font-size: 16px;
+      padding-top: 10px;
+    }
   }
 
 
@@ -1485,18 +1488,15 @@ a.transfer {
     }
   }
 
-  a .delete {
+  a.delete {
     background-image:url(/assets/status/remove-sign.png);
     background-repeat: no-repeat;
     display:inline-block;
-    margin:auto;
-    width:25px;
-    height: 25px;
     padding-left: 23px;
     color: @odiCrimson;
   }
 
-  a:hover .delete {
+  a.delete:hover {
    color: @odiCrimsonDark;
   }
 
@@ -1512,10 +1512,8 @@ a.transfer {
 
 .response-set .row-fluid.baseline {
 
-    // Even out the spacing around the last line of data in each certificate
-    // panel on the "My Certificates" page
-    padding-bottom: 5px;
-
+    font-size: 16px;
+    padding-top: 10px;
 }
 
 // don't display the headers, links or actions in secondary ones

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -218,7 +218,7 @@ class SurveyorController < ApplicationController
 
   def switch_survey(attrs, survey)
     attrs = prepare_new_response_set
-    attrs[:survey_id] = survey.id
+    attrs['survey_id'] = survey.id
     create_new_response_set(attrs)
   end
 

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -213,7 +213,9 @@ class SurveyorController < ApplicationController
   def switch_survey(survey)
     attrs = prepare_new_response_set
     attrs['survey_id'] = survey.id
+    response_set = @response_set
     create_new_response_set(attrs)
+    response_set.supercede!
   end
 
 end

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -207,9 +207,8 @@ class SurveyorController < ApplicationController
   end
 
   def prepare_new_response_set
-    @response_set.attributes.keep_if do |key|
-      %w(survey_id user_id dataset_id).include? key
-    end
+    keep = %w[survey_id user_id dataset_id]
+    @response_set.attributes.slice(*keep)
   end
 
   def create_new_response_set(attrs)

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -16,8 +16,6 @@ class SurveyorController < ApplicationController
 
   # it might be a *really* nice refactor to take this to response_set_controller#update
   # then we could use things like `form_for [surveyor, response_set] do |f|`
-  #
-  # also, GET here is totally totally wrong
   def continue
     if params[:survey_locale]
       @response_set.update_attribute :locale, params[:survey_locale]

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -29,8 +29,7 @@ class SurveyorController < ApplicationController
       survey = Survey.newest_survey_for_access_code nxt
 
       unless survey.nil?
-        attrs = prepare_new_response_set
-        switch_survey(attrs, survey)
+        switch_survey(survey)
       end
 
     elsif params[:juristiction_access_code]
@@ -38,8 +37,7 @@ class SurveyorController < ApplicationController
 
       survey = Survey.newest_survey_for_access_code(params[:juristiction_access_code])
       unless survey.nil?
-        attrs = prepare_new_response_set
-        switch_survey(attrs, survey)
+        switch_survey(survey)
 
         # the user has made a concious effort to switch jurisdictions, so set it as their default
         if user_signed_in?
@@ -50,8 +48,7 @@ class SurveyorController < ApplicationController
     elsif @response_set.survey.superceded?
       latest_survey = Survey.newest_survey_for_access_code(params[:survey_code])
       unless latest_survey.nil?
-        attrs = prepare_new_response_set
-        switch_survey(attrs, latest_survey)
+        switch_survey(latest_survey)
       end
     elsif !@response_set.modifications_allowed?
       # they *actually* want to create a new response set
@@ -215,7 +212,7 @@ class SurveyorController < ApplicationController
     @response_set = ResponseSet.clone_response_set(@response_set, attrs)
   end
 
-  def switch_survey(attrs, survey)
+  def switch_survey(survey)
     attrs = prepare_new_response_set
     attrs['survey_id'] = survey.id
     create_new_response_set(attrs)

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -60,7 +60,7 @@ class Response < ActiveRecord::Base
   end
 
   def ui_hash_values
-    [:datetime_value, :integer_value, :float_value, :unit, :text_value, :string_value, :response_other, :explanation].reduce({}) do |memo, key|
+    [:datetime_value, :integer_value, :float_value, :unit, :text_value, :string_value, :response_other, :response_group, :explanation].reduce({}) do |memo, key|
       value = self.send(key)
       memo[key] = value unless value.blank?
       memo

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -378,8 +378,7 @@ class ResponseSet < ActiveRecord::Base
           api_id = Surveyor::Common.generate_api_id
           ui_hash[api_id] = { question_id: question.id.to_s,
                               api_id: api_id,
-                              answer_id: answer.id.to_s,
-                              response_group: previous_response.response_group }.merge(previous_response.ui_hash_values)
+                              answer_id: answer.id.to_s }.merge(previous_response.ui_hash_values)
         end
       end
     end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -382,7 +382,7 @@ class ResponseSet < ActiveRecord::Base
         end
       end
     end
-    update_from_ui_hash(ui_hash)
+    original_update_from_ui_hash(ui_hash)
   end
 
   # run updates through the response_cache_map, so that we can deal

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -95,12 +95,18 @@ class ResponseSet < ActiveRecord::Base
 
     state :archived
 
+    state :superceded
+
     event :publish do
       transitions from: :draft, to: :published, guard: :all_mandatory_questions_complete?
     end
 
     event :archive do
       transitions from: :published, to: :archived
+    end
+
+    event :supercede do
+      transitions from: [:draft, :published], to: :superceded
     end
   end
 

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -74,7 +74,7 @@ class ResponseSet < ActiveRecord::Base
   end
 
   def self.clone_response_set(source, attrs = {})
-    attrs["survey_id"] ||= source.survey_id
+    attrs = {"survey_id" => source.survey_id}.merge(attrs)
     new_response_set = ResponseSet.create attrs
     new_response_set.kitten_data = source.kitten_data.dup if source.kitten_data.present?
     new_response_set.copy_answers_from_response_set!(source)

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -47,7 +47,7 @@
         </td>
         <td>
             <% if can? :edit, generator.response_set %>
-            <%= link_to "edit", continue_path(generator.response_set) %>
+                <%= button_to "edit", continue_path(generator.response_set), method: 'post' %>
             <% end %>
         </td>
         <td>

--- a/app/views/datasets/_response_set.html.haml
+++ b/app/views/datasets/_response_set.html.haml
@@ -47,10 +47,8 @@
     .span3.edit-jurisdiction
       %h3 Your answers
       -if is_primary
-        %p
-          = link_to 'Edit Questionnaire', continue_path(response_set), class: 'btn btn-large btn-info btn-block edit_questionaire'
-        %p
-          = link_to 'Change Jurisdiction', "#switch-#{response_set.id}", data: {toggle: :modal, content: t('dashboard.popover.change_jurisdiction') }, class: 'popdown'
+        %p= button_to 'Edit Questionnaire', continue_path(response_set), method: 'post', class: 'btn btn-large btn-info btn-block edit_questionaire'
+        %p= link_to 'Change Jurisdiction', "#switch-#{response_set.id}", data: {toggle: :modal, content: t('dashboard.popover.change_jurisdiction') }, class: 'popdown'
 
         =render :partial => 'shared/switch_jurisdiction', locals: {response_set: response_set}
 

--- a/app/views/datasets/_response_set.html.haml
+++ b/app/views/datasets/_response_set.html.haml
@@ -56,18 +56,10 @@
 
   .row-fluid.baseline
     .span3
-      %p
-      %small
-        = link_to t('dashboard.improvements_link'), improvements_dataset_certificate_path(response_set.dataset, certificate)
+      = link_to t('dashboard.improvements_link'), improvements_dataset_certificate_path(response_set.dataset, certificate)
     .span3
-      %p
-      %small
-        = t 'dashboard.last_updated_at', time_span: time_ago_in_words(response_set.updated_at)
+      = t 'dashboard.last_updated_at', time_span: time_ago_in_words(response_set.updated_at)
     .span3
-      %p
-      %small= "#{t('dashboard.verification')}: #{t(certificate.certification_type, scope: 'certificate.certification_types')}"
+      = "#{t('dashboard.verification')}: #{t(certificate.certification_type, scope: 'certificate.certification_types')}"
     .span3
-      = link_to [surveyor, response_set], {:method => :delete, :confirm => t('dashboard.confirm_deletion'), data: {confirm_title: t('dashboard.confirm_deletion_dialog_title')}} do
-        %p
-        %small.delete
-          Delete
+      = link_to 'Delete', [surveyor, response_set], {:method => :delete, :confirm => t('dashboard.confirm_deletion'), data: {confirm_title: t('dashboard.confirm_deletion_dialog_title')}, class: 'delete'}

--- a/app/views/surveyor/requirements.html.haml
+++ b/app/views/surveyor/requirements.html.haml
@@ -11,7 +11,7 @@
           %h3= @response_set.title
         .span3
           -if @response_set.incomplete?
-            =link_to t('improvements.return_to_questionnaire'), resume_path, :class => 'btn btn-primary btn-large return', :role => "button"
+            =button_to t('improvements.return_to_questionnaire'), resume_path, :method => 'post', :class => 'btn btn-primary btn-large return', :role => "button"
           -else
             =link_to t('improvements.return_to_dashboard'), dashboard_path, :class => 'btn btn-primary btn-large return', :role => "button"
 
@@ -50,8 +50,7 @@
                     .span4
                       %p= markdown(field.help_text || '')
                     .span6.offset2
-                      %a.btn.btn-primary.btn-large{:href => resume_path(field)}
-                        =t('improvements.buttons.understood')
+                      =button_to t('improvements.buttons.understood'), resume_path(field), method: 'post', class: 'btn btn-primary btn-large'
                       %a.btn.btn-primary.btn-large.btn-negative{:href => comment_path(topic: field.discussion_topic, back: request.original_fullpath, title: field.text, question_id: field.id)}
                         =t('improvements.buttons.misunderstood')
               %hr.heavy
@@ -71,8 +70,7 @@
                     .span4
                       %p= markdown(answer.try(:help_text) || question.try(:help_text) || '')
                     .span6.offset2
-                      %a.btn.btn-primary.btn-large{:href => resume_path(question)}
-                        =t('improvements.buttons.understood')
+                      =button_to t('improvements.buttons.understood'), resume_path(question), method: 'post', class: 'btn btn-primary btn-large'
                       %a.btn.btn-primary.btn-large.btn-negative{:href => comment_path(topic: question.discussion_topic, back: request.original_fullpath, title: question.text, question_id: question.id)}
                         =t('improvements.buttons.misunderstood')
               %hr.heavy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,7 @@ en:
       draft: Draft
       published: Published
       archived: Archived
+      superceded: Superceded
     expiring_states:
       expired: Expired
       expiring: 'Expires in %{days} days'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ OpenDataCertificate::Application.routes.draw do
   mount Surveyor::Engine => "/surveys", :as => "surveyor"
   Surveyor::Engine.routes.draw do
     get '/:survey_code/:response_set_code/requirements', :to => 'surveyor#requirements', :as => 'view_my_survey_requirements'
-    get '/:survey_code/:response_set_code/continue', :to => 'surveyor#continue', :as => 'continue_my_survey'
+    post '/:survey_code/:response_set_code/continue', :to => 'surveyor#continue', :as => 'continue_my_survey'
     get '/:survey_code/:response_set_code/repeater_field/:question_id/:response_index/:response_group', :to => 'surveyor#repeater_field', :as => 'repeater_field'
     get '/:survey_code/:response_set_code/save_and_finish', :to => 'surveyor#force_save_questionnaire', :as => 'force_save_questionnaire'
 


### PR DESCRIPTION
Stop causing multiple copies of response sets to be generated.

The process is still slow and will time out but this will reduce the issue to one of speed and not data integrity.