### PR TITLE
Allow CORS access to `.js` files as well as `.json`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -97,6 +97,7 @@ module OpenDataCertificate
       allow do
         origins '*'
         resource '/datasets/*.json', :headers => :any, :methods => [:get, :options]
+        resource '/datasets/*.js', :headers => :any, :methods => [:get, :options]
       end
     end
 


### PR DESCRIPTION
CORS headers for .js files were disabled when the setup was changed.

This was stopping badge embedding code when being loaded dynamically.