### PR TITLE
Hotfix: copying url from old response set

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -60,11 +60,15 @@ class Response < ActiveRecord::Base
   end
 
   def ui_hash_values
-    [:datetime_value, :integer_value, :float_value, :unit, :text_value, :string_value, :response_other, :response_group, :explanation].reduce({}) do |memo, key|
+    values = [:datetime_value, :integer_value, :float_value, :unit, :text_value, :string_value, :response_other, :response_group, :explanation].reduce({}) do |memo, key|
       value = self.send(key)
       memo[key] = value unless value.blank?
       memo
     end
+    if answer.response_class == 'text'
+      values[:text_value] ||= values[:string_value]
+    end
+    return values
   end
 
   def dataset

--- a/test/unit/response_set_test.rb
+++ b/test/unit/response_set_test.rb
@@ -61,6 +61,26 @@ class ResponseSetTest < ActiveSupport::TestCase
     assert response_set.responses.first.try(:string_value) == response_value
   end
 
+  test "copies urls from old string_value responses to newer text_value columns" do
+    response_value = rand.to_s
+    q=FactoryGirl.create(:question, reference_identifier: :question_identifier)
+    a=FactoryGirl.create(:answer, reference_identifier: :answer_identifier, question: q, response_class: 'text')
+
+    source_response_set = FactoryGirl.create(:response_set, survey: a.question.survey_section.survey)
+    FactoryGirl.create :response, { response_set: source_response_set,
+                                    string_value: response_value,
+                                    answer_id: a.id,
+                                    question_id: a.question.id }
+    source_response_set.reload
+
+    response_set = FactoryGirl.create :response_set, survey: source_response_set.survey
+    response_set.reload
+
+    response_set.copy_answers_from_response_set!(source_response_set)
+
+    assert response_set.responses.first.try(:text_value) == response_value
+  end
+
   test "copies explanations for responses along with answers" do
     q=FactoryGirl.create(:question, reference_identifier: :question_identifier)
     a=FactoryGirl.create(:answer, reference_identifier: :answer_identifier, question: q, input_type: 'url')


### PR DESCRIPTION
Copy url into `text_value` column due to update to questionnaire.