### PR TITLE
More Czech localization fixes

### DIFF
--- a/prototype/jurisdictions/certificate.CZ.xml
+++ b/prototype/jurisdictions/certificate.CZ.xml
@@ -371,7 +371,7 @@
                         <strong>Informace o držiteli databázových práv, uvedené v právním prohlášení, by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.</requirement>
                   </option>
                </checkboxset>
-               <help more="https://github.com/theodi/open-data-licensing/blob/master/guides/publisher-guide.md">Je dobrým zvykem uvádět informace o právech ve strojově čitelné podobě, aby uživatelé vašich dat mohli snadno uvést vaše autorství.</help>
+               <help>Je dobrým zvykem uvádět informace o právech ve strojově čitelné podobě, aby uživatelé vašich dat mohli snadno uvést vaše autorství.</help>
             </question>
          </if>
       </group>

--- a/prototype/jurisdictions/certificate.CZ.xml
+++ b/prototype/jurisdictions/certificate.CZ.xml
@@ -18,14 +18,14 @@
                <option value="yes">
                   <label>Ano, máme právo zveřejnit tato data jako otevřená.</label>
                   <requirement level="standard">
-                     <strong>Ke zveřejnění dat byste měli mít nezpochybnitelné právo.</strong>
+                     <strong>Na zveřejnění dat byste měli mít jasný právní nárok.</strong>
                   </requirement>
                </option>
                <option value="no">
                   <label>Ne, nemáme právo ke zveřejnění těchto dat jako otevřených.</label>
                </option>
                <option value="unsure">
-                  <label>Nejsme si jisti, jestli máme právo data zveřejnit.</label>
+                  <label>Nejsme si jisti, jestli máme právo data zveřejnit jako otevřená.</label>
                </option>
                <option value="complicated">
                   <label>Práva k těmto datům jsou nejasná nebo složitá.</label>
@@ -40,16 +40,16 @@
          </question>
          <if test="this.publisherRights() === 'complicated'">
             <question id="rightsRiskAssessment" display="Právní rizika spojená s užitím dat">
-               <label>Kde popisujete právní rizika, se kterými je užití dat spojeno?</label>
+               <label>Kde konkretizujete právní rizika, se kterými je užití dat spojeno?</label>
                <input type="url" placeholder="URL dokumentace"/>
-               <help>Užití dat bez nezpochybnitelných práv je riskantní – například se může stát, že budete data muset přestat data poskytovat na základě stížnosti. Uveďte URL stránky, na které se uživatelé o podobných rizicích dozví.</help>
+               <help>Užití dat bez jasného právního nároku je riskantní – například se může stát, že budete data muset přestat data poskytovat na základě právní výzvy. Uveďte URL stránky, na které se uživatelé o podobných rizicích dozví.</help>
                <requirement level="pilot">
-                  <strong>Měli byste popsat možná rizika spojená s užitím vašich dat</strong>, aby se uživatelé mohli rozhodnout, jestli a jak je mohou užít.</requirement>
+                  <strong>Popište možná rizika spojená s užitím vašich dat</strong>, aby se uživatelé mohli rozhodnout, jestli a jak je mohou užít.</requirement>
             </question>
          </if>
          <if test="this.publisherRights() === 'yes' || this.publisherRights() === 'unsure'">
             <question id="publisherOrigin" display="Původ dat">
-               <label>Shromáždili jste <em>všechna</em> data sami?</label>
+               <label>Shromáždili nebo vytvořili jste <em>všechna</em> data sami?</label>
                <yesno required="required" yes="data byla vytvořena přímo poskytovatelem"/>
                <help>Pokud jakákoliv část dat pochází ze zdrojů mimo vaši organizaci, je třeba uvést další informace o právech k jejich zveřejnění.</help>
             </question>
@@ -61,14 +61,14 @@
                   <yesno required="required"/>
                   <help>I výtah, případně malá část použitého cizího textu, může mít vliv na vaše práva k užití. Stejně tak v případě, že jste analyzovali cizí data a vytvořili výstup odlišný od původních dat.</help>
                   <if test="this.crowdsourced() === 'false'">
-                     <requirement test="this.thirdPartyOrigin() === 'true'">Uvedli jste, že jste data nevytvořili ani samostaně nesesbírali (včetně formy crowdsourcingu), takže musela vzniknout vytěžením nebo zpracováním cizích datových zdrojů.</requirement>
+                     <requirement test="this.thirdPartyOrigin() === 'true'">Uvedli jste, že jste data nevytvořili ani samostaně nesesbírali (ani formou crowdsourcingu), takže musela vzniknout vytěžením nebo zpracováním cizích datových zdrojů.</requirement>
                   </if>
                </question>
                <if test="this.thirdPartyOrigin() === 'true'">
                   <question id="thirdPartyOpen" display="Zdroje dat">
                      <label>Vycházeli jste <em>výhradně</em> z otevřených dat?</label>
                      <yesno required="required" yes="výhradně otevřená data"/>
-                     <help>Cizí data můžete publikovat pouze v případě, že byla zveřejněna pod otevřenou licencí, práva původního držitele vypršela nebo si jich držitel vzdal. Pokud to pro sebemenší část dat neplatí, musíte se před jejich zveřejněním poradit s právníky.</help>
+                     <help>Cizí data můžete publikovat pouze v případě, že byla zveřejněna pod otevřenou licencí, práva k nim vypršela nebo si jich držitel vzdal. Pokud to pro jakoukoliv část dat neplatí, musíte se před jejich zveřejněním poradit s právníky.</help>
                      <if test="this.thirdPartyOpen() === 'false'">
                         <requirement>
                            <strong>Měli byste se poradit s právníky, abyste měli jistotu, že data můžete publikovat.</strong>
@@ -78,30 +78,31 @@
                </if>
                <question id="crowdsourced" display="Crowdsourcing">
                   <label>Vznikla nějaká část dat pomocí crowdsourcingu?</label>
-                  <yesno required="required" yes="aspoň část dat vznikla crowdsourcingem"/>
+                  <yesno required="required" yes="aspoň část dat vznikla pomocí crowdsourcingu"/>
                   <help>Pokud nějaká část dat pochází od osob mimo vaši organizaci, musíte si od nich vyžádat svolení k publikování dat pod otevřenou licencí.</help>
                   <if test="this.thirdPartyOrigin() === 'false'">
-                     <requirement test="this.crowdsourced() === 'true'">Uvedli jste, že data původně nepochází od vás a nevznikla ani výběrem nebo zpracováním cizích dat, takže musela vzniknout pomocí crowdsourcingu.</requirement>
+                     <requirement test="this.crowdsourced() === 'true'">Uvedli jste, že jste data nevytvořili nebo samostaně nesesbírali, ani jste nevytěžili nebo nezpracovali cizí datové zdroje, data tedy musela vzniknout pomocí crowdsourcingu.</requirement>
                   </if>
                </question>
                <if test="this.crowdsourced() === 'true'">
                   <question id="crowdsourcedContent">
                      <label>Dá se práce přispěvatelů považovat za tvůrčí?</label>
                      <yesno required="required"/>
-                     <help>Na tvůrčí práci vyžadující jedinečný úsudek autora mají přispěvatelé autorská práva. Příkladem tvůrčí práce je například psaní popisků nebo i rozhodování o tom, kterou část zdrojových dat vybrat do výsledné datové sady. Pokud taková data chcete publikovat, přispěvatelé se musí vzdát svých autorských práv, převést je na vás, nebo vám data licencovat.</help>
+                     <help>Přispěvatelé mají autorská práva k dílům, která jsou jedinečným a tvůrčím výsledkem jejich činnosti. Příkladem tvůrčí práce je například psaní popisů nebo i rozhodování o tom, kterou část zdrojových dat vybrat do výsledné datové sady. Pokud taková data chcete publikovat, přispěvatelé vám je musí licencovat.</help>
                   </question>
                   <if test="this.crowdsourcedContent() === 'true'">
                      <question id="claUrl" display="Přispěvatelská licenční dohoda (CLA)">
-                        <label>Kde máte vystavenou přispěvatelskou licenční dohodu (CLA)?</label>
-                        <input type="url" placeholder="URL licenční dohody" required="required"/>
-                        <help more="http://en.wikipedia.org/wiki/Contributor_License_Agreement">Uveďte odkaz na dokument, ve kterém vám přispěvatelé dovolují užití svých dat. Konkrétně se přispěvatelé mohou vzdát svých autorských práv, převést je na vás, nebo vám udělit licenci k jejich užití.</help>
+                        <label>Kde je možné najít přispěvatelskou licenční smlouvu (CLA)?</label>
+                        <input type="url" placeholder="URL přispěvatelské licenční smlouvy" required="required"/>
+                        <help more="http://en.wikipedia.org/wiki/Contributor_License_Agreement">Uveďte odkaz na dokument, ve kterém vám přispěvatelé dovolují užití svých dat. Přispěvatelé vám mohou udělit licenci k užití jejich autorských děl.</help>
                      </question>
                      <question id="cldsRecorded">
-                        <label>Souhlasili všichni přispěvatelé s přispěvatelskou licenční dohodou (CLA)?</label>
+                        <label>Souhlasili všichni přispěvatelé s přispěvatelskou licenční smlouvou (CLA)?</label>
                         <yesno required="required"/>
-                        <help>Abyste mohli zveřejnit cizí příspěvky, musí jejich autoři souhlasit s přispěvatelskou licenční dohodou (CLA). Měli byste si vést seznam jednotlivých přispěvatelů a poznačit si, kteří souhlasili s přispěvatelskou licenční dohodou (CLA).</help>
+                        <help>Abyste mohli zveřejnit cizí příspěvky, musí jejich autoři souhlasit s přispěvatelskou licenční smlouvou (CLA). Je vhodné vést seznam jednotlivých přispěvatelů, kteří souhlasili s přispěvatelskou licenční smlouvou (CLA).</help>
                         <requirement>
-                           <strong>Každý přispěvatel musí souhlasit s přispěvatelskou licenční dohodou (CLA)</strong>, ve které vám uděluje právo zveřejnit jeho práci pod otevřenou licencí.</requirement>
+                           <strong>Každý přispěvatel musí souhlasit s přispěvatelskou licenční smlouvou (CLA)</strong>, ve které vám uděluje právo zveřejnit svou práci pod otevřenou licencí.
+                        </requirement>
                      </question>
                   </if>
                </if>
@@ -113,13 +114,14 @@
                <input type="url" placeholder="URL k dokumentaci datových zdrojů"/>
                <help>Uveďte URL dokumentu, ve kterém popisujete zdroje dat a licenci, která vám umožňuje data zveřejnit.</help>
                <requirement level="pilot">
-                  <strong>Měli byste popsat, odkud pochází data a vaše práva je zveřejnit</strong>, aby uživatelé mohli bez obav použít i data pocházející z cizích zdrojů.</requirement>
+                <strong>Popište, odkud data pochází a jaká jsou vaše práva je zveřejnit</strong>, aby uživatelé mohli bez obav použít i data pocházející z cizích zdrojů.
+               </requirement>
             </question>
             <if test="this.sourceDocumentationUrl() !== ''">
                <question id="sourceDocumentationMetadata" display="Strojově čitelné zdroje dat">
                   <label>Máte dokumentaci o zdrojích dat i ve strojově čitelné podobě?</label>
                   <yesno yes="zdroje dat jsou strojově čitelné"/>
-                  <help>Informace o zdrojích dat byste měli kromě lidsky srozumitelné podoby zveřejnit i ve strojově čitelném formátu. Díky tomu se dá lépe zjistit, jak jsou data používána, což zároveň vysvětluje jejich opakovanou publikaci.</help>
+                  <help>Díky strojově čitelnému odkazu na zdroj dat se dá lépe zjistit, kde všude se data používají – a to je dobrý argument pro to, aby zůstala otevřená.</help>
                   <requirement level="standard">
                      <strong>Měli byste zveřejnit strojově čitelné informace o zdrojích, ze kterých vaše data pochází.</strong>
                   </requirement>
@@ -133,7 +135,7 @@
          <question id="copyrightURL" display="Právní prohlášení">
             <label>Kde jste zveřejnili prohlášení o právech k této datové sadě?</label>
             <input type="url" placeholder="URL právního prohlášení"/>
-            <help>Uveďte URL dokumentu, který popisuje práva k opětovnému užití této datové sady. Dokument by měl odkazovat na text licence, popsat vaše požadavky na uvádění autorství, a obsahovat prohlášení o relevantních autorských a databázových právech. Právní prohlášení pomáhá uživatelům pochopit, co všechno s daty mohou a nemohou dělat.</help>
+            <help>Uveďte URL dokumentu, který popisuje práva k opětovnému užití této datové sady. Dokument by měl odkazovat na text licence, popsat vaše požadavky na uvádění původu, a obsahovat prohlášení o relevantních autorských a databázových právech. Právní prohlášení pomáhá uživatelům pochopit, co všechno s daty mohou a nemohou dělat.</help>
             <requirement level="pilot">
                <strong>Měli byste zveřejnit právní prohlášení</strong>, které podrobně popíše autorská a databázová práva spojená s vašimi daty, licenční podmínky a vaše požadavky na uvádění autorství.</requirement>
          </question>
@@ -141,16 +143,16 @@
             <label>Pod jakou licencí dáváte data k dispozici?</label>
             <select required="required">
                <option/>
-               <option value="cc-by">Creative Commons Attribution</option>
-               <option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-               <option value="cc-zero">Creative Commons CCZero</option>
+               <option value="cc-by">Creative Commons Uveďte původ</option>
+               <option value="cc-by-sa">Creative Commons Uveďte původ + Zachovejte licenci</option>
+               <option value="cc-zero">Creative Commons CC0</option>
                <option value="odc-by">Open Data Commons Attribution License</option>
                <option value="odc-odbl">Open Data Commons Open Database License (ODbL)</option>
                <option value="odc-pddl">Open Data Commons Public Domain Dedication and License (PDDL)</option>
                <option value="na" display="">nehodí se</option>
                <option value="other" display="">jiná…</option>
             </select>
-            <help>Nezapomeňte na to, že k databázi drží práva každý, kdo data původně nasbíral, vytvořil, zkontroloval nebo vybral. Autorská práva mohou vznikat také při reorganizaci dat. Každý uživatel tedy potřebuje licenci k použití dat nebo doklad o tom, že se všichni autoři svých autorských práv vzdali. Do seznamu jsme vybrali nejčastěji používané licence. Pokud žádná autorská ani databázová práva nejsou ve hře, vypršela, nebo se jich autoři vzdali, vyberte možnost „nehodí se“.</help>
+            <help>Nezapomeňte, že k databázi má práva kdokoliv, kdo přispěl k jejímu vytváření tvůrčím vkladem. Tvůrčím vkladem může být i uspořádání nebo výběr dat, nikoliv však přidání obecně známých skutečností. Každý uživatel tedy potřebuje licenci k použití dat nebo doklad o tom, že na nich neváznou další práva, či se jedná o zákonnou výjimku. Do seznamu jsme vybrali nejčastěji používané licence. Pokud žádná autorská ani databázová práva nejsou ve hře, vypršela, nebo se jich pořizovatelé databáze vzdali, vyberte možnost „nehodí se“.</help>
          </question>
          <if test="this.dataLicence() === 'na'">
             <question id="dataNotApplicable" display="Důvody chybějící licence">
@@ -159,11 +161,11 @@
                   <option value="norights"
                           display="na data se nevztahuje žádná autorskoprávní ochrana">
                      <label>Na data se nevztahují žádná autorská ani databázová práva.</label>
-                     <help>Databázová práva vznikají například vynaložením netriviálního úsilí při sběru, ověřování nebo prezentaci dat. Naopak nevznikají například u dat neověřovaných, vytvořených od nuly, nebo prezentovaných nějakým zjevným způsobem. Autorská práva k datům vznikají například při výběru nebo netriviální reorganizaci dat.</help>
+                     <help>Databázová práva vznikají při vynaložení netriviálního úsilí při sběru, ověřování nebo prezentaci dat, při přispění tvůrčím vkladem ke vzniku databáze. Naopak nevznikají například u faktů nebo prostých souborů dat bez uspořádání.</help>
                   </option>
                   <option value="expired" display="práva k datům vypršela">
                      <label>práva k datům vypršela</label>
-                     <help>Ochrana databázových práv trvá deset let. Pokud se data naposledy měnila před více než deseti lety, databázová práva nejspíš vypršela. Pevnou dobu trvají také autorská majetková práva; lhůta se počítá od úmrtí autora nebo od vydání díla. Stručně řečeno je nepravděpodobné, že by u vašich dat autorská práva vypršela.</help>
+                     <help>Ochrana databázových práv trvá patnáct let od vzniku databáze nebo posledního kvalitativně nebo kvantitativně podstatného vkladu do databáze spočívajícím v doplnění, zkrácení či jiných úpravách. Pokud se data naposledy měnila před více než patnácti lety, databázová práva vypršela. Pevnou dobu trvají také autorská majetková práva; lhůta se počítá 70 let od úmrtí autora. Je tedy nepravděpodobné, že by u vašich dat autorská práva vypršela.</help>
                   </option>
                   <option value="waived" display="">
                      <label>vlastníci se vzdali svých práv</label>
@@ -173,14 +175,14 @@
             </question>
             <if test="this.dataNotApplicable() === 'waived'">
                <question id="dataWaiver" display="Forma vzdání se autorských práv k datům">
-                  <label>Jakým způsobem jste se autorských práv vzdali?</label>
+                  <label>Jakým způsobem poskytujete svá autorská majetková práva?</label>
                   <select required="required">
                      <option/>
                      <option value="pddl">Open Data Commons Public Domain Dedication and License (PDDL)</option>
-                     <option value="cc0">Creative Commons CCZero</option>
+                     <option value="cc0">Creative Commons CC0</option>
                      <option value="other" display="">jiný…</option>
                   </select>
-                  <help>Musíte dát uživatelům nějak konkrétně najevo, že jste se práv vzdali a mohou si s daty nakládat podle svého. Můžete použít některý se standardních mechanismů, například PDDL nebo CCZero, nebo napsat vlastní právní dokument.</help>
+                  <help>Musíte dát uživatelům najevo, že mohou s daty nakládat téměř neomezeně za předpokladu, že dodrží podmínky licence. Můžete použít některý se standardních mechanismů, například PDDL nebo CC0, nebo vytvořit vlastní licenční smlouvu dle rad právníka.</help>
                </question>
                <if test="this.dataWaiver() === 'other'">
                   <question id="dataOtherWaiver" display="Forma vzdání se autorských práv k datům">
@@ -192,13 +194,13 @@
             </if>
          </if>
          <if test="this.dataLicence() === 'other'">
-            <question id="otherDataLicenceName" display="Data jsou licencována pod">
+            <question id="otherDataLicenceName" display="Data jsou dostupná pod">
                <label>Jaký je název použité licence?</label>
                <input required="required" placeholder="název licence"/>
                <help>Pokud data zveřejňujete pod jinou než nabízenou licencí, potřebujeme znát její název – bude součástí vašeho certifikátu otevřených dat.</help>
             </question>
             <question id="otherDataLicenceURL" display="Text licence">
-               <label>Kde uživatelé najdou text licence?</label>
+               <label>Kde uživatelé najdou plný text licence?</label>
                <input type="url" required="required" placeholder="URL k licenci"/>
                <help>Uveďte URL licence. Bude součástí vašeho certifikátu otevřených dat, aby si licenci mohl kdokoliv přečíst.</help>
             </question>
@@ -207,7 +209,7 @@
                <yesno required="required"/>
                <help more="http://opendefinition.org/">Definici „otevřené licence“ najdete na serveru <a href="http://opendefinition.org/od/czech/">OpenDefinition.org</a>. Tamtéž najdete přímo <a href="http://opendefinition.org/licenses/">seznam otevřených licencí</a>. Pokud v něm vaše licence chybí, buď není otevřená, nebo ji ještě nikdo neposoudil.</help>
                <requirement>
-                  <strong>Otevřená data musíte publikovat pod otevřenou licencí</strong>, aby s nimi uživatelé mohli volně nakládat.</requirement>
+                  <strong>Otevřená data musíte publikovat pod otevřenou licencí</strong>, aby je uživatelé mohli používat.</requirement>
             </question>
          </if>
          <question id="contentRights" display="Obsah chráněný autorským právem">
@@ -215,15 +217,15 @@
             <radioset required="required">
                <option value="norights" display="ne, data obsahují pouze fakta a čísla">
                   <label>Ne, data obsahují pouze fakta a čísla.</label>
-                  <help>Při licencování dat je občas dobré (nebo přímo nutné) posuzovat zvlášť obsah databáze a zvlášť databázi jako takovou. Tato otázka se vztahuje přímo na obsah databáze. Pokud databáze neobsahuje nic, co by vzniklo tvůrčím úsilím, autorské právo se na její obsah nevztahuje.</help>
+                  <help>K faktickým informacím nevznikají autorská práva. Pokud databáze neobsahuje nic, co by vzniklo tvůrčím úsilím, autorské právo se na její obsah nevztahuje.</help>
                </option>
                <option value="samerights" display="ano; držitel práv pouze jeden">
                   <label>Ano, a všemi právy disponuje jeden člověk nebo organizace.</label>
-                  <help>Tuto možnost vyberte, pokud data obsahují nějaký autorským právem chráněný obsah a veškerými právy k tomuto obsahu disponuje jedna osoba nebo organizace.</help>
+                  <help>Tuto možnost vyberte, pokud byla data vytvořena jednou osobou nebo organizací nebo předána jedné osobě nebo organizaci.</help>
                </option>
                <option value="mixedrights" display="ano; více různých držitelů práv">
                   <label>Ano, a držitelem práv jsou různé osoby a organizace.</label>
-                  <help>U některých dat se mohou držitelé autorských práv lišit záznam od záznamu. V tom případě by informace o právech měly být součástí dat.</help>
+                  <help>U některých dat se mohou držitelé práv lišit záznam od záznamu. V tom případě by informace o jednotlivých právech měly být součástí dat.</help>
                </option>
             </radioset>
          </question>
@@ -231,39 +233,40 @@
             <question id="explicitWaiver" display="Je obsah dat volným dílem?">
                <label>Je obsah dat volným dílem, tedy Public Domain?</label>
                <yesno yes="ano, obsah dat je volným dílem"/>
-               <help>K prohlášení obsahu za volné dílo můžete použít například licenci <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. Tak se uživatelé snadno dozvědí, že mohou s obsahem dat volně nakládat.</help>
+               <help>K označení obsahu jako volné dílo můžete použít například licenci <a href="http://creativecommons.org/publicdomain/">Creative Commons Public Domain Mark</a>. Tak se uživatelé snadno dozvědí, že mohou s obsahem dat volně nakládat.</help>
                <requirement level="standard">
-                  <strong>Pokud je nějaká část obsahu vašich dat volným dílem, měli byste ji zveřejnit pod vhodnou licencí</strong>, aby uživatelé věděli, že s tímto obsahem mohou volně nakládat.</requirement>
+                  <strong>Pokud je nějaká část obsahu vašich dat volným dílem, měli byste ji vhodně označit</strong>, aby uživatelé věděli, že s tímto obsahem mohou volně nakládat.
+                  </requirement>
             </question>
          </if>
          <if test="this.contentRights() === 'samerights'">
             <question id="contentLicence" display="Licence obsahu">
-               <label>Pod jakou licencí zveřejňujete obsah dat?</label>
+               <label>Pod jakou licencí mohou ostatní znovu užívat tento obsah?</label>
                <select required="required">
                   <option/>
-                  <option value="cc-by">Creative Commons Attribution</option>
-                  <option value="cc-by-sa">Creative Commons Attribution Share-Alike</option>
-                  <option value="cc-zero">Creative Commons CCZero</option>
+                  <option value="cc-by">Creative Commons Uveďte původ</option>
+                  <option value="cc-by-sa">Creative Commons Uveďte původ + Zachovejte licenci</option>
+                  <option value="cc-zero">Creative Commons CC0</option>
                   <option value="na" display="">nehodí se</option>
                   <option value="other" display="">jiná…</option>
                </select>
-               <help>Nezapomeňte, že každé tvůrčí úsilí automaticky vede ke vzniku autorských práv k vytvořenému obsahu (s výjimkou čistě faktických údajů). Pokud tedy uživatelé chtějí váš obsah bez problémů používat, potřebují odpovídající licenci nebo dokument, ve kterém se vzdáváte svých autorských práv. V seznamu uvádíme nejčastěji používané licence. Pokud váš obsah není chráněný autorským právem, práva vypršela nebo jste se jich vzdali, vyberte možnost „nehodí se“.</help>
+               <help>Nezapomeňte, že každé tvůrčí úsilí automaticky vede ke vzniku autorských práv k vytvořenému obsahu (s výjimkou čistě faktických údajů). Pokud tedy uživatelé chtějí váš obsah bez problémů používat, potřebují odpovídající licenci nebo dokument, ve kterém se vzdáváte svých práv, pokud je to možné. V seznamu uvádíme nejčastěji používané licence. Pokud váš obsah není chráněný autorským právem, práva vypršela nebo jste se jich vzdali, vyberte možnost „nehodí se“.</help>
             </question>
             <if test="this.contentLicence() === 'na'">
                <question id="contentNotApplicable" display="Důvody chybějící licence">
-                  <label>Proč se na obsah dat nevztahuje žádná licence?</label>
+                  <label>Proč není obsah dat licencován?</label>
                   <radioset required="required">
-                     <option value="norights" display="na obsah se nevztahují autorská práva">
-                        <label>Na obsah dat se nevztahují žádná autorská práva.</label>
-                        <help>Autorská práva vznikají pouze tehdy, když k vytvoření obsahu vynaložíte netriviální tvůrčí úsilí, například psaním popisků. Pokud data obsahují pouze fakta, autorský zákon se na ně nevztahuje.</help>
+                     <option value="norights" display="na datovou sadu se nevztahují autorská práva">
+                        <label>Datová sada není chráněna autorským právem.</label>
+                        <help>Autorské právo chrání literární a jiná umělecká a vědecká díla, která jsou jedinečným výsledkem tvůrčí činnosti autora. Pokud data obsahují pouze fakta, autorskoprávní ochrana se na ně nevztahuje.</help>
                      </option>
-                     <option value="expired" display="autorská práva už vypršela">
-                        <label>Autorská práva už vypršela.</label>
-                        <help>Autorská práva platí pouze omezenou dobu, počítanou buď od vydání díla, nebo od úmrtí autora. Zkontrolujte si datum vzniku a vydání obsahu – pokud je obsah dostatečně starý, autorská práva už mohla vypršet.</help>
+                     <option value="expired" display="autorskoprávní ochrana díla vypršela">
+                        <label>Autorskoprávní ochrana díla již vypršela.</label>
+                        <help>Majetková práva k autorskému dílu jsou chráněna jen po určitou dobu od smrti autora (70 let počínaje prvním lednem po smrti) nebo vydání díla. Ověřte si datum vzniku díla, protože pokud je dostatečně staré, majetková ochrana autorksých práv již mohla vypršet.</help>
                      </option>
-                     <option value="waived" display="autor se vzdal svých práv">
-                        <label>Autor se svých práv vzdal.</label>
-                        <help>To znamená, že práva nikdo nevlastní a každý si s obsahem může nakládat podle svého.</help>
+                     <option value="waived" display="autor se vzdal ochrany svých práv">
+                        <label>Autor se vzdal ochrany svých práv.</label>
+                        <help>To znamená, že držitelem majetkových práv k dílu není nikdo a každý může s dílem nakládat volně, při zachování osobnostních práv.</help>
                      </option>
                   </radioset>
                </question>
@@ -272,19 +275,19 @@
                      <label>Jakým způsobem jste se vzdali svých práv?</label>
                      <select required="required">
                         <option/>
-                        <option value="cc0">Creative Commons CCZero</option>
+                        <option value="cc0">Creative Commons CC0</option>
                         <option value="other">jiný…</option>
                      </select>
-                     <help>Pokud jste se autorských práv k obsahu vzdali, musíte to nějak doložit, aby uživatelé věděli, že s obsahem mohou bez rizika nakládat. Autorských práv se můžete vzdát nějakým zavedeným způsobem, třeba pomocí CCZero, ale i vlastním právním dokumentem.</help>
+                     <help>Pokud se chcete vzdát autorskoprávní ochrany vašeho obsahu, je třeba tak učinit prokazatelným způsobem, aby ostatní uživatelé věděli, že mohou váš obsah bez obav užívat. K tomu je možné použít již existujících prostředků, jako je CC0, nebo s právní pomocí napsat vlastní licenční ujednání.</help>
                   </question>
                   <if test="this.contentWaiver() === 'other'">
                      <question id="contentOtherWaiver"
-                               display="Forma upuštění od autorských práv k obsahu">
-                        <label>Kde je dokument, ve kterém se vzdáváte práv k obsahu?</label>
+                               display="Forma upuštění od majetkových práv k obsahu">
+                        <label>Kde je dokument, kterým se vzdáváte práv k obsahu?</label>
                         <input type="url"
                                required="required"
-                               placeholder="URL k právnímu dokumentu"/>
-                        <help>Uveďte URL k veřejně dostupnému dokumentu, kterým se vzdáváte práv k obsahu dat. Uživatelé si díky němu mohou ověřit, že je obsah skutečně bez právních závazků.</help>
+                               placeholder="URL právního dokumentu"/>
+                        <help>Uveďte URL k veřejně dostupnému dokumentu, kterým se vzdáváte majetkových práv k obsahu dat. Uživatelé si díky němu mohou ověřit, že mohou s Vaším obsahem volně nakládat.</help>
                      </question>
                   </if>
                </if>
@@ -295,9 +298,9 @@
                   <input required="required" placeholder="název licence"/>
                   <help>Pokud používáte jinou licenci, potřebujeme znát její název, abychom ho mohli uvést na certifikátu otevřených dat.</help>
                </question>
-               <question id="otherContentLicenceURL" display="Text licence k obsahu">
-                  <label>Kde je plný text této licence?</label>
-                  <input type="url" required="required" placeholder="URL k licenci"/>
+               <question id="otherContentLicenceURL" display="Text licenčního ujednání k obsahu">
+                  <label>Kde je plný text licenčního ujednání?</label>
+                  <input type="url" required="required" placeholder="URL k licenčnímu ujednání"/>
                   <help>Uveďte URL licenčního textu. Bude uvedeno na vašem certifikátu otevřených dat, aby si kdokoliv mohl licenci zkontrolovat.</help>
                </question>
                <question id="otherContentLicenceOpen">
@@ -305,18 +308,18 @@
                   <yesno required="required"/>
                   <help more="http://opendefinition.org/">Definici „otevřené licence“ najdete na serveru <a href="http://opendefinition.org/od/czech/">OpenDefinition.org</a>. Tamtéž najdete přímo <a href="http://opendefinition.org/licenses/">seznam otevřených licencí</a>. Pokud v něm vaše licence chybí, buď není otevřená, nebo ji ještě nikdo neposoudil.</help>
                   <requirement>
-                     <strong>Data musíte zveřejnit pod otevřenou licencí, aby je ostatní mohli užít.</strong>
+                    <strong>Data musíte zveřejnit pod otevřenou licencí, aby je ostatní mohli užít. Pokud data nejsou jakkoli chráněná, připojte prosím informaci o tomto stavu k datové sadě.</strong>
                   </requirement>
                </question>
             </if>
          </if>
          <if test="this.contentRights() === 'mixedrights'">
-            <question id="contentRightsURL" display="Právní prohlášení k obsahu dat">
-               <label>Kde popisujete právní a licenční podmínky spojené s obsahem dat?</label>
+            <question id="contentRightsURL" display="Práva a licence k obsahu">
+               <label>Kde popisujete licenční podmínky a práva spojená s obsahem dat?</label>
                <input type="url"
                       required="required"
-                      placeholder="URL právního prohlášení"/>
-               <help>Uveďte URL stránky, na které vysvětlujete právní a licenční podmínky spojené s obsahem dat.</help>
+                      placeholder="URL dokumentu"/>
+               <help>Uveďte URL stránky, na které vysvětlujete licenční podmínky a práva spojená s obsahem dat.</help>
             </question>
          </if>
          <if test="this.copyrightURL() !== ''">
@@ -327,48 +330,57 @@
                   <option value="dataLicense" display="licence k datům">
                      <label>licence k datům</label>
                      <requirement level="standard">
-                        <strong>Informace o licenci dat uvedené v právním prohlášení by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.</requirement>
+                        <strong>Informace o použité licenci k datům by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.
+                    </requirement>
                   </option>
-                  <option value="contentLicense" display="licence k obsahu">
-                     <label>licence k obsahu</label>
+                  <option value="contentLicense" display="licence k autorskoprávně chráněnému obsahu">
+                     <label>licence k autorskoprávně chráněnému obsahu</label>
                      <requirement level="standard">
-                        <strong>Informace o licenci obsahu uvedené v právním prohlášení by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.</requirement>
+                        <strong>Informace o použité licenci k autorskoprávně chráněnému obsahu by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.
+                    </requirement>
                   </option>
                   <option value="attribution" display="způsob uvádění autorství">
                      <label>způsob uvádění autorství</label>
                      <requirement level="standard">
-                        <strong>Požadovaný způsob uvádění autorství, který popisujete v právním prohlášení, by měl být strojově čitelný</strong>, aby se dal zpracovat automatickými nástroji.</requirement>
+                        <strong>Informace o autorství by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.
+                    </requirement>
                   </option>
                   <option value="attributionURL" display="URL pro uvedení autorství">
                      <label>URL pro uvedení autorství</label>
                      <requirement level="standard">
-                        <strong>Požadovaný způsob uvádění autorství, který popisujete v právním prohlášení, by měl být strojově čitelný</strong>, aby se dal zpracovat automatickými nástroji.</requirement>
+                        <strong>Uvedení autora by mělo být strojově čitelné</strong>, aby se dal zpracovat automatickými nástroji.
+                    </requirement>
                   </option>
                   <option value="copyrightNotice" display="informace o autorských právech">
                      <label>informace o autorských právech</label>
                      <requirement level="exemplar">
-                        <strong>Informace o autorských právech uvedené v právním prohlášení by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.</requirement>
+                        <strong>Informace o autorských právech by měla být strojově čitelná</strong>, aby se dala zpracovat automatickými nástroji.
+                    </requirement>
                   </option>
-                  <option value="copyrightYear" display="letopočet spojený s autorskými právy">
-                     <label>letopočet spojený s autorskými právy</label>
+                  <option value="copyrightYear" display="rok registrace copyrightu (americké právo)">
+                     <label>rok registrace copyrightu (americké právo)</label>
                      <requirement level="exemplar">
-                        <strong>Letopočet, spojený s autorskými právy, uvedený v právním prohlášení, by měl být strojově čitelný</strong>, aby se dal zpracovat automatickými nástroji.</requirement>
+                        <strong>Rok registrace copyrightu (americké právo) by měl být strojově čitelný</strong>, aby se dal zpracovat automatickými nástroji.
+                    </requirement>
                   </option>
                   <option value="copyrightHolder" display="držitel autorských práv">
                      <label>držitel autorských práv</label>
                      <requirement level="exemplar">
-                        <strong>Informace o držiteli autorských práv uvedené v právním prohlášení by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.</requirement>
+                        <strong>Informace o držiteli autorských práv by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.
+                    </requirement>
                   </option>
                   <option value="databaseRightYear"
                           display="letopočet spojený s databázovými právy">
                      <label>letopočet spojený s databázovými právy</label>
                      <requirement level="exemplar">
-                        <strong>Letopočet databázových práv, uvedený v právním prohlášení, by měl být strojově čitelný</strong>, aby se dal zpracovat automatickými nástroji.</requirement>
+                        <strong>Rok vzniku databáze nebo posledního nový kvalitativně nebo kvantitativně podstatného vkladu by měl být strojově čitelný</strong>, aby se dal zpracovat automatickými nástroji.
+                    </requirement>
                   </option>
-                  <option value="databaseRightHolder" display="držitel databázových práv">
-                     <label>držitel databázových práv</label>
+                  <option value="databaseRightHolder" display="pořizovatel databáze">
+                     <label>pořizovatel databáze</label>
                      <requirement level="exemplar">
-                        <strong>Informace o držiteli databázových práv, uvedené v právním prohlášení, by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.</requirement>
+                        <strong>Informace o pořizovateli databáze by měly být strojově čitelné</strong>, aby se daly zpracovat automatickými nástroji.
+                    </requirement>
                   </option>
                </checkboxset>
                <help>Je dobrým zvykem uvádět informace o právech ve strojově čitelné podobě, aby uživatelé vašich dat mohli snadno uvést vaše autorství.</help>
@@ -376,24 +388,24 @@
          </if>
       </group>
       <group id="privacy">
-         <label>Ochrana osobních údajů</label>
+         <label>Ochrana soukromí</label>
          <help>jak chránit soukromí osob</help>
-         <question id="dataPersonal" display="Ochrana osobních údajů">
-            <label>Dají se podle vašich dat identifikovat konkrétní osoby?</label>
+         <question id="dataPersonal" display="Ochrana soukromí">
+            <label>Dají se podle vašich dat identifikovat konkrétní fyzické osoby?</label>
             <radioset required="pilot">
                <option value="not-personal"
-                       display="nehraje roli, data se netýkají jednotlivců">
-                  <label>Ne, data se netýkají jednotlivců.</label>
+                       display="nehraje roli, data se netýkají fyzických osob">
+                  <label>Ne, data se netýkají konkrétních fyzických osob.</label>
                   <help>Nezapomeňte na to, že konkrétní osoba se dá identifikovat i nepřímo. Například byste mohli někoho identifikovat podle statistik dopravního provozu, ve spojení s informacemi o tom, kdy a kam daná osoba dojíždí.</help>
                </option>
                <option value="summarised" display="nehraje roli, jde o agregovaná data">
-                  <label>Ne. Jde o agregovaná data, která vznikla spojováním dat o jednotlivcích do větších celků. Jednotlivci jsou v rámci skupiny nerozlišitelní a tudíž anonymní.</label>
+                  <label>Ne. Jde o agregovaná data, která vznikla spojováním dat o jednotlivcích do větších celků, takže již nejde rozlišit konkrétní fyzické osoby.</label>
                   <help>Skutečná anonymita jednotlivců v agregovaných datech se dá ověřit statistickými metodami.</help>
                </option>
                <option value="individual"
-                       display="data, která mohou sloužit k identifikaci osob">
-                  <label>Ano, existuje riziko, že by data mohla vést k identifikaci konkrétních osob, například nějakou třetí stranou disponující souvisejícími daty.</label>
-                  <help>Některá data o konkrétních osobách se dají zveřejnit bez problémů, například platy státních zaměstnanců – v některých zemích – nebo veřejné výdaje.</help>
+                       display="data mohou sloužit k identifikaci fyzických osob">
+                  <label>Ano, existuje riziko, že by data mohla vést k identifikaci konkrétních fyzických osob, například nějakou třetí stranou disponující souvisejícími daty.</label>
+                  <help>Některá data o konkrétních fyzických osobách se dají zveřejnit bez problémů, například platy státních zaměstnanců – v některých zemích – nebo veřejné výdaje.</help>
                </option>
             </radioset>
          </question>
@@ -414,20 +426,21 @@
             <if test="this.appliedAnon() === 'false'">
                <question id="lawfulDisclosure" display="Publikace daná zákonem">
                   <label>Jste ze zákona povinni nebo oprávněni zveřejňovat tato osobní data?</label>
-                  <yesno yes="zveřejnění dat je přikázáno zákonem"/>
+                  <yesno yes="zveřejnění osobních údajů je povoleno/přikázáno zákonem"/>
                   <help>
-                     <strong>Osobní data byste bez anonymizace měli zveřejňovat jen v případech, kdy vám to povoluje nebo nařizuje zákon.</strong>
+                    <strong>Osobní údaje můžete bez anonymizace zveřejňovat jen v případech, kdy vám to zákon nařizuje nebo umožňuje.</strong>
                   </help>
                   <requirement level="pilot">
                      <strong/>
                   </requirement>
                </question>
                <if test="this.lawfulDisclosure() === 'true'">
-                  <question id="lawfulDisclosureURL" display="Právo ke zveřejnění osobních dat">
-                     <label>Který dokument vám umožnuje zveřejnit osobní data?</label>
+                  <question id="lawfulDisclosureURL" display="Právo ke zveřejnění osobních údajů">
+                     <label>Máte někde záznamy o možnosti publikovat osobní údaje, například Souhlasy subjektů údajů?</label>
                      <input type="url" placeholder="URL s odůvodněním"/>
                      <requirement level="standard">
-                        <strong>Měli byste zveřejnit, odkud plynou vaše práva k publikování osobních údajů</strong>. Usnadníte tím situaci uživatelům svých dat i lidem, kterých se data týkají.</requirement>
+                        <strong>Měli byste uvést, odkud plynou vaše práva ke zveřejnění osobních údajů</strong>. Usnadníte tím situaci uživatelům svých dat i lidem, kterých se data týkají.
+                    </requirement>
                   </question>
                </if>
             </if>
@@ -445,9 +458,10 @@
                   <question id="riskAssessmentUrl" display="Analýza rizik">
                      <label>Kde máte analýzu rizik zveřejněnou?</label>
                      <input type="url" placeholder="URL analýzy rizik"/>
-                     <help>Uveďte URL dokumentu, kde si mohou zájemci ověřit vaši analýzu rizik práce s osobními údaji. Pokud analýza obsahuje citlivé informace, můžete ji pouze shrnout nebo příslušné části cenzurovat.</help>
+                     <help>Uveďte URL dokumentu, kde si mohou zájemci ověřit vaši analýzu rizik práce s osobními údaji. Pokud analýza obsahuje citlivé informace, můžete ji pouze shrnout nebo příslušné části odstranit nebo anonymizovat.</help>
                      <requirement level="standard">
-                        <strong>Analýzu rizik spojených s osobními údaji byste měli zveřejnit</strong>, aby se zájemci mohli podívat, nakolik s příslušnými riziky počítáte.</requirement>
+                        <strong>Analýzu rizik spojených s osobními údaji byste měli zveřejnit</strong>, aby se zájemci mohli podívat, jakým způsobem předcházíte možným rizikům.
+                    </requirement>
                   </question>
                   <if test="this.riskAssessmentUrl() !== ''">
                      <question id="riskAssessmentAudited" display="Audit analýzy rizik">
@@ -462,7 +476,7 @@
                      <question id="individualConsentURL" display="Informace pro dotčené osoby">
                         <label>Kde máte sdělení o ochraně osobních údajů dotčených osob?</label>
                         <input type="url" placeholder="URL dokumentu"/>
-                        <help more="http://www.ico.org.uk/for_organisations/data_protection/the_guide/principle_2">Pokud sbíráte data o jednotlivých lidech, musíte jim oznámit, co budete s daty dělat. Prohlášení o soukromí dotčených osob bude zajímat i uživatele vašich dat, aby se nedostali do sporu se zákonem na ochranu osobních údajů.</help>
+                        <help more="https://www.uoou.cz/VismoOnline_ActionScripts/File.ashx?id_org=200144&amp;id_dokumenty=11914">Při sběru a zpracování osobních údajů musíte dotčené osoby (subjekty údajů) informovat o probíhajícím zpracování, tedy za jakým účelem data zpracováváte, jak dlouho se tak bude dít, kdo bude mít k datům přístup a podobně. Prohlášení o soukromí dotčených osob bude zajímat i uživatele vašich dat, aby se nedostali do sporu se zákonem na ochranu osobních údajů.</help>
                         <requirement level="pilot">
                            <strong>Musíte uživatelům svých dat vysvětlit, k jakému využití svých osobních dat daly dotčené osoby svolení</strong>, aby se vaši uživatelé nedostali do sporu se zákonem na ochranu osobních údajů.</requirement>
                      </question>
@@ -473,10 +487,10 @@
                   </question>
                   <if test="this.dpStaff() === 'true'">
                      <question id="dbStaffConsulted" display="Zodpovědnost za ochranu osobních údajů">
-                        <label>Podílel se na analýze rizik?</label>
+                        <label>Podílel se na analýze rizik spojených s ochranou soukromí?</label>
                         <yesno yes="zodpovědná osoba se podílela na analýze rizik"/>
                         <requirement level="pilot">
-                           <strong>Pokud máte někoho přímo zodpovědného za ochranu osobních údajů, měli byste ho přizvat k analýze rizik.</strong>
+                           <strong>Pokud máte někoho přímo zodpovědného za ochranu osobních údajů, měli byste ho přizvat k analýze souvisejících rizik.</strong>
                         </requirement>
                      </question>
                   </if>

--- a/prototype/translations/certificate.cz.xml
+++ b/prototype/translations/certificate.cz.xml
@@ -656,7 +656,7 @@
                   </option>
                   <option value="resolvable" display="snadná, identifikátory jsou URL">
                      <label>Ano, identifikátory jsou URL, takže je stačí otevřít.</label>
-                     <help>URL jsou užitečné pro počítače i pro lidi. Lidé si mohou URL snadno otevřít ve svém prohlížeči a dohledat tak informace třeba o <a href="http://opencorporates.com/companies/gb/08030289">firmě</a> nebo <a href="http://data.ordnancesurvey.co.uk/doc/postcodeunit/EC2A4JE">PSČ</a>. Stejně snadno se k těmto informacím dostane počítač, například ve skriptech.</help>
+                     <help>URL jsou užitečné pro počítače i pro lidi. Lidé si mohou URL snadno otevřít ve svém prohlížeči a dohledat tak informace třeba o firmě nebo PSČ. Stejně snadno se k těmto informacím dostane počítač, například ve skriptech.</help>
                      <requirement level="exemplar">
                         <strong>K objektům ve svých datech byste měli uvádět také URL</strong>, aby uživatelé mohli snadno najít a sdílet související informace.</requirement>
                   </option>
@@ -700,7 +700,7 @@
          <question id="provenance" display="Informace o původu dat">
             <label>Publikujete strojově čitelná metadata o původu dat?</label>
             <yesno yes="strojově čitelné"/>
-            <help more="http://www.w3.org/TR/prov-primer/">Je dobré zveřejnit, kde jste k datům přišli a jak jste je zpracovávali. Uživatelé pak mohou vašim datům víc věřit, protože vědí, co jste s nimi dělali.</help>
+            <help>Je dobré zveřejnit, kde jste k datům přišli a jak jste je zpracovávali. Uživatelé pak mohou vašim datům víc věřit, protože vědí, co jste s nimi dělali.</help>
             <requirement level="exemplar">
                <strong>Měli byste zveřejnit strojově čitelný záznam o původu a zpracování dat</strong>, aby uživatelé věděli, co jste s daty dělali.</requirement>
          </question>


### PR DESCRIPTION
Mostly changes after the online version was reviewed by our lawyers. I have only made changes to the XML files this time around, not updating the source translation spreadsheet anymore. This means that the XML files are now the only authoritative version of the Czech localization – hopefully that’s not an issue.

Apart from this, we have an update to the licensing part of the questionnaire in the pipeline. (It looks like we have to change the questionnaire content a bit in order to fit the Czech law.)