### PR TITLE
Remove unnecessarily encrypted test environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,5 @@ env:
   global:
   - secure: ktiYuRyE9BN2wa65zkATI37ABnL5I/eUfV3FDnSzDKqhcN7QhqiqzGKRiPXsXRkQRloUoP9p2AZH4rhHUSkWtdtJWMlCzgkh3PHjNFHRGIwL6YfeEOiMMbRrhnwpT4uAjPAahxsUZRnc7TmsoFSRazALgK8DQ+SdN3vt5pwJZU8=
   - secure: fFtR5aMYwdFBKDaj+2u3HsDuVAO9SUZ25sMqxp17y1RSQa0zUTEMGtXZhjVn5VTX14voYDmo0vYkqtxovXBrPfFn0jdENYum+yu38XuLmFdReLoIh1EzC/pT9xTLNkYfGZj/a+IPIlj0TPkSHOSj6vuV/aT85QSUx+gpisfnCoA=
-  - secure: W/BRRQ3WK92W7olcCAwAJnYFuHfyNunrA6MCTwecOX4hCLw1900lSKs0MnJ7QvdiBvzuo/qLBKsfaZoNGoIwTgpT2P3MFcnJozehhPXkAaWixIkmN3u1oeZ6OdDDU9NIYgUzm8lzoqXGiTbIb4z5lZMmfx+j/CZXoT86V+b1U4U=
-  - secure: Li3T6biupLWMx3dvzqzR2qS28HaOCiiyzm/MxVmexvwLGgiTVV4py+LwTGXfI6niJ5gzt1SLOLUW0ZnBtN4qv8mtQKcFgKkkpt62eeBxCwWGu7pbJ0rjz7ujiQsR70XsW8c0McAwYavRxlHD83KGdVlXklhZ+4+lnduhlIpgYAY=
-  - GAPPS_CERTIFICATE_USAGE_COLLECTION="ODI Drive/Technical/Test Data/Usage Data"
 git:
   depth: 10

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,10 @@ Spork.prefork do
 end
 
 Spork.each_run do
+  # ENVARS that need to be presnet in the env before being escaped by VCR
+  ENV['GAPPS_USER_EMAIL'] = "GAPPS_USER_EMAIL"
+  ENV['GAPPS_PASSWORD'] = "GAPPS_PASSWORD"
+
   VCR.configure do |c|
     # Automatically filter all secure details that are stored in the environment
     ignore_env = %w{SHLVL RUNLEVEL GUARD_NOTIFY DRB COLUMNS USER LOGNAME LINES TERM_PROGRAM_VERSION}
@@ -35,10 +39,11 @@ Spork.each_run do
     # -- they do not yet inherit this setting
     # fixtures :all
 
-    # Add more helper methods to be used by all tests here...
-
+    # Configuration ENVARS:
     ENV['RACKSPACE_CERTIFICATE_DUMP_CONTAINER'] = "certificates_test"
+    ENV['GAPPS_CERTIFICATE_USAGE_COLLECTION'] = "ODI Drive/Technical/Test Data/Usage Data"
 
+    # Add more helper methods to be used by all tests here...
     def assert_attribute_exists(model, attribute)
       assert_respond_to model, attribute
     end


### PR DESCRIPTION
These variables don’t need to be encrypted as they are not real values. They are used by code that tests gdrive against vcr.

Previously pull requests made by people outside the ODI failed as Travis would not decrypt these envars.