### PR TITLE
Change jurisdiction via POST

### DIFF
--- a/app/views/shared/_switch_jurisdiction.html.haml
+++ b/app/views/shared/_switch_jurisdiction.html.haml
@@ -5,6 +5,6 @@
   .modal-body
     %p= t 'response_set.dialog_body'
     =# form_for [surveyor, response_set] do |f| (see surveyor#continue refactor note)
-    = form_tag surveyor.continue_my_survey_path(survey_code: response_set.survey.access_code, response_set_code: response_set.access_code), method: :get, :class => 'form-inline' do
+    = form_tag surveyor.continue_my_survey_path(survey_code: response_set.survey.access_code, response_set_code: response_set.access_code), method: :post, :class => 'form-inline' do
       = select_tag(:juristiction_access_code, jurisdiction_options_for_select)
       = submit_tag t('response_set.start_new_jurisdiction'), :class => 'btn btn-primary btn-submit'


### PR DESCRIPTION
Operations that change survey should be POSTs not GETs

Problem was introduced by changes from #1133

Fixes #1158