### PR TITLE
Remove memcache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ group :production do
   gem 'mysql2'
   gem 'airbrake'
   gem 'delayed-plugins-airbrake'
-  gem 'memcache-client'
   gem 'logstash-event'
   gem 'lograge'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,6 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    memcache-client (1.8.5)
     memoist (0.9.3)
     metaclass (0.0.4)
     method_source (0.8.2)
@@ -507,7 +506,6 @@ DEPENDENCIES
   linkeddata
   lograge
   logstash-event
-  memcache-client
   memoist
   mocha
   mysql2

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -7,13 +7,9 @@ OpenDataCertificate::Application.configure do
   # Full error reports are disabled and caching is turned on
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
-  
-  if ENV["MEMCACHED_HOSTS"]
-    config.cache_store = :mem_cache_store, ENV["MEMCACHED_HOSTS"]
-  else
-    config.cache_store = :memory_store
-  end
-  
+
+  config.cache_store = :memory_store
+
   config.lograge.enabled = true
   config.lograge.log_format = :logstash
 
@@ -84,7 +80,7 @@ OpenDataCertificate::Application.configure do
     }
 
   end
-  
+
   # Enable threaded mode
   # config.threadsafe!
 


### PR DESCRIPTION
It's more trouble than it's worth for what we use it for.

Rails.cache is only used to store response codes from urls we test, this can be done in memory for now.