### PR TITLE
Fix link to edit questionnaire

### DIFF
--- a/app/views/certificates/show.html.haml
+++ b/app/views/certificates/show.html.haml
@@ -29,7 +29,7 @@
           - if @certificate.draft?
             %li
               .btn.btn-small.btn-info.pull-right{disabled:'disabled'}= t 'certificate.not_yet_published'
-            %li=link_to t('certificate.edit_questionnaire'), surveyor.continue_my_survey_path(survey_code: @certificate.response_set.survey.access_code, response_set_code: @certificate.response_set.access_code), class: 'btn btn-small btn-info pull-left'
+            %li=link_to t('certificate.edit_questionnaire'), surveyor.continue_my_survey_path(survey_code: @certificate.response_set.survey.access_code, response_set_code: @certificate.response_set.access_code), method: 'post', class: 'btn btn-small btn-info pull-left'
         - elsif @certificate.auto_generated?
           %li=link_to(t('certificate.claim_this_certificate'), "#claim-#{@certificate.id}", :class => 'btn btn-small btn-info', :'data-toggle' => :modal)
 


### PR DESCRIPTION
The method for continue has changed to a post.

I couldn’t style a `button_to` correctly so it’s currently a `link_to` with the `:method => :post`, which is sad and wrong but fixes it for most.