### PR TITLE
Set REDIS_URL in rake file

### DIFF
--- a/lib/tasks/certificate_factory.rake
+++ b/lib/tasks/certificate_factory.rake
@@ -1,4 +1,5 @@
 require File.join(Rails.root, 'lib/extra/certificate_factory.rb')
+ENV['REDIS_URL'] = ENV['ODC_REDIS_SERVER_URL']
 
 task :certificate do
   ENV['JURISDICTION'] ||= "gb"


### PR DESCRIPTION
Just tested this in staging, and, because the whole Rails env doesn't get pulled in, the Redis URL doesn't get set properly. This fixes it.