### PR TITLE
Use ENVARS for configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
   - secure: ktiYuRyE9BN2wa65zkATI37ABnL5I/eUfV3FDnSzDKqhcN7QhqiqzGKRiPXsXRkQRloUoP9p2AZH4rhHUSkWtdtJWMlCzgkh3PHjNFHRGIwL6YfeEOiMMbRrhnwpT4uAjPAahxsUZRnc7TmsoFSRazALgK8DQ+SdN3vt5pwJZU8=
   - secure: fFtR5aMYwdFBKDaj+2u3HsDuVAO9SUZ25sMqxp17y1RSQa0zUTEMGtXZhjVn5VTX14voYDmo0vYkqtxovXBrPfFn0jdENYum+yu38XuLmFdReLoIh1EzC/pT9xTLNkYfGZj/a+IPIlj0TPkSHOSj6vuV/aT85QSUx+gpisfnCoA=
   - ODC_REDIS_SERVER_URL="redis://localhost:6379"
+  - CERTIFICATE_HOSTNAME="test.host"
   - COVERAGE=1
 git:
   depth: 10

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,10 +14,6 @@ module OpenDataCertificate
     ENV['CERTIFICATE_HOSTNAME']
   end
 
-  def self.staging?
-    /staging/ =~ Dir.pwd
-  end
-
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ end
 
 module OpenDataCertificate
   def self.hostname
-    ::OpenDataCertificate::Application.config.action_mailer[:default_url_options][:host]
+    ENV['CERTIFICATE_HOSTNAME']
   end
 
   def self.staging?

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ OpenDataCertificate::Application.configure do
 
   # config.action_mailer.default_url_options = { :host => 'localhost:3000' }
   config.action_mailer.default_url_options = {
-    :host => "#{'staging.' if OpenDataCertificate.staging?}certificates.theodi.org"
+    :host => ENV["CERTIFICATE_HOSTNAME"]
   }
 
   # For testing on heroku we're using the mandril addon on odc-stage.herokuapp.com

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,7 +1,7 @@
 if ENV['AIRBRAKE_CERTIFICATE_KEY']
   Airbrake.configure do |config|
     config.api_key = ENV['AIRBRAKE_CERTIFICATE_KEY']
-    config.environment_name = OpenDataCertificate.staging? ? "staging" : Rails.env
+    config.environment_name = ENV['AIRBRAKE_ENV']
 
     # displayed in the 500.html error page
     config.user_information = "Exception ID <strong>{{ error_id }}</strong>"


### PR DESCRIPTION
For mailer hostname, url building and airbrake setup use ENVARS explicitly set in infrastructure config instead of deriving or guessing them from other settings.