### PR TITLE
Speedup Save+Publish actions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,15 +26,9 @@ class ApplicationController < ActionController::Base
         # Assign the response set to the user, creating a dataset for it
         response_set.assign_to_user!(current_user)
 
-        if params[:form_id] == 'save_and_finish_modal_form'
-          # if the user has authenticated from the save_and_finish_modal_form then redirect to the force_save_questionnaire path
-          surveyor.force_save_questionnaire_path(:survey_code => response_set.survey.access_code, :response_set_code => response_set.access_code)
-        else
-          surveyor.edit_my_survey_path(
-            :survey_code => response_set.survey.access_code,
-            :response_set_code => response_set.access_code
-          )
-        end
+        surveyor.edit_my_survey_path(
+          :survey_code => response_set.survey.access_code,
+          :response_set_code => response_set.access_code)
 
       when params[:form_id] == 'start_cert_modal_form'
         # if the user has authenticated from the start_cert_modal_form then redirect to the start_questionnaire path

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -67,12 +67,6 @@ class SurveyorController < ApplicationController
     redirect_to surveyor.edit_my_survey_path(redirect_options)
   end
 
-  def force_save_questionnaire
-    # This action is used when the user has signed-in after clicking the "save and finish" link. It mocks up the request as if it were an already-logged-in user that clicked "save and finish"
-    params[:finish] = true
-    update
-  end
-
   def update
     if @response_set
 
@@ -80,12 +74,9 @@ class SurveyorController < ApplicationController
         return redirect_with_message(surveyor_index, :warning, t('surveyor.response_set_is_published'))
       end
 
-      # Remove and track the finish trigger to prevent surveyor completing the survey premuturely
-      finish = params.delete(:finish)
-
       saved = load_and_update_response_set_with_retries
 
-      if saved && finish
+      if saved
         flash[:_saved_response_set] = @response_set.access_code
 
         if user_signed_in?

--- a/app/views/surveyor/edit.html.haml
+++ b/app/views/surveyor/edit.html.haml
@@ -34,7 +34,7 @@
               %h1{'data-bind-to-input' => @survey.meta_map[:dataset_title]}= @response_set.title
             .span3.save-button
               - if user_signed_in?
-                %button.btn.btn-primary.btn-large.pull-right{type: :submit, name: :finish, "data-btn-loading" => t('surveyor.saving_questionnaire')}
+                %button.btn.btn-primary.btn-large.pull-right{type: :submit, name: :finish}
                   %i.icon-loading.icon-spin.icon-refresh.icon-large
                   %span= t('surveyor.click_here_to_finish')
               - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -270,7 +270,7 @@ en:
     choose_language: --- Select language ---
     start_new_language: Change language
 
-    update_instructions: "Please check the information is up to date and all the mandatory fields are completed. Select 'Save and finish' to update."
+    update_instructions: "Please check the information is up to date and all the mandatory fields are completed before continuing."
 
   summary_data:
     summary: Summary

--- a/config/locales/surveyor_en.yml
+++ b/config/locales/surveyor_en.yml
@@ -13,7 +13,7 @@ en:
     unable_to_find_that_survey: "Unable to find that questionnaire"
     please_choose_a_legislation: "Please choose a jurisdiction"
     survey_started_success: "Questionnaire started successfully"
-    click_here_to_finish: "Save and finish"
+    click_here_to_finish: "Continue"
     saving_questionnaire: "Saving"
     previous_section: "&laquo; Previous section"
     next_section: "Next section &raquo;"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ OpenDataCertificate::Application.routes.draw do
     get '/:survey_code/:response_set_code/requirements', :to => 'surveyor#requirements', :as => 'view_my_survey_requirements'
     post '/:survey_code/:response_set_code/continue', :to => 'surveyor#continue', :as => 'continue_my_survey'
     get '/:survey_code/:response_set_code/repeater_field/:question_id/:response_index/:response_group', :to => 'surveyor#repeater_field', :as => 'repeater_field'
-    get '/:survey_code/:response_set_code/save_and_finish', :to => 'surveyor#force_save_questionnaire', :as => 'force_save_questionnaire'
 
     get  '/:survey_code/:response_set_code/start', :to => 'surveyor#start', as: 'start'
     get '/:survey_code/:response_set_code', :to => redirect('/surveys/%{survey_code}/%{response_set_code}/take', status: 302)

--- a/test/functional/surveyor_controller_test.rb
+++ b/test/functional/surveyor_controller_test.rb
@@ -73,7 +73,7 @@ class SurveyorControllerTest < ActionController::TestCase
     assert_redirected_to "/surveys/#{r.survey.access_code}/#{r.access_code}/take"
   end
 
-  test "update an expired questionnaire" do
+  test "updating a response_set is published if it was from an update to an already published response set" do
     @response_set = FactoryGirl.create(:response_set)
 
     sign_in @response_set.user
@@ -81,8 +81,7 @@ class SurveyorControllerTest < ActionController::TestCase
     post :update, use_route: :surveyor,
                   survey_code: @response_set.survey.access_code,
                   response_set_code: @response_set.access_code,
-                  update: true,
-                  finish: true
+                  update: true # this indicates it was previously published
 
     @response_set.reload
     assert_equal true, ResponseSet.last.published?


### PR DESCRIPTION
Improve the speed of save and publish actions by reducing the amount of work they do re-saving the questionnaire.