### PR TITLE
Setup assetpipeline clearly

### DIFF
--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -15,8 +15,9 @@
 
 *= require_self
 *= require surveyor_all
-*= require datasets
+*= require campaigns
 *= require claims
+*= require datasets
 *= require mermaid
 */
 

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :header_title, "Certification campaign: #{@campaign.name}" %>
-<% content_for :meta, stylesheet_link_tag('campaigns', :media => 'print') %>
 
 <h3><%= report_heading(@certificate_level) %></h3>
 <div class='schedule-controls omit-in-print'>

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,7 +72,12 @@ module OpenDataCertificate
 
     # Add homepage map to the asset pipeline
     config.assets.paths << Rails.root.join("app", "assets", "homepage_map")
-    config.assets.precompile += %w( map.js )
+    config.assets.precompile += %w[
+      admin.js
+      map.js
+
+      badge.css
+    ]
 
     # Get around heroku deployment issues
     # https://devcenter.heroku.com/articles/rails-asset-pipeline#troubleshooting

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ OpenDataCertificate::Application.configure do
   # config.action_controller.asset_host = "http://assets.example.com"
 
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  config.assets.precompile += %w( badge.css admin.js campaigns.css)
+  config.assets.precompile += %w( badge.css admin.js)
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,9 +50,6 @@ OpenDataCertificate::Application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 
-  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  config.assets.precompile += %w( badge.css admin.js)
-
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 


### PR DESCRIPTION
Move all asset pipeline setup into `application.rb` or dependencies in asset files.

Instead of putting some in `production.rb` which was not a safe place as additions could be forgotten about.