### PR TITLE
A specific load balancer check endpoint

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -1,5 +1,13 @@
 class MainController < ApplicationController
 
+  def ping
+    if ActiveRecord::Base.connection.active?
+      head :ok
+    else
+      head :service_unavailable
+    end
+  end
+
   def home
     @surveys = Survey.available_to_complete
     respond_to do |format|

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,6 +12,7 @@ OpenDataCertificate::Application.configure do
 
   config.lograge.enabled = true
   config.lograge.log_format = :logstash
+  config.lograge.ignore_actions = %w[main#ping]
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
   config.serve_static_assets = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,8 @@ OpenDataCertificate::Application.routes.draw do
   # Flowchart
   get 'flowchart' => 'flowcharts#show'
 
+  get 'status/ping' => 'main#ping'
+
   # The priority is based upon order of creation:
   # first created -> highest priority.
 

--- a/test/functional/main_controller_test.rb
+++ b/test/functional/main_controller_test.rb
@@ -140,4 +140,19 @@ class MainControllerTest < ActionController::TestCase
     assert_equal assigns(:dataset).user_id, @user.id, "dataset belongs to user"
   end
 
+  test "ping page returns ok" do
+    get :ping
+    assert_response 200
+  end
+
+  test "ping page checks status of database" do
+    ActiveRecord::Base.connection.stubs(:active?).returns(false)
+    get :ping
+    assert_response 503
+  end
+
+  test "ping is available on status/ping" do
+    assert_routing '/status/ping', controller: 'main', action: 'ping'
+  end
+
 end


### PR DESCRIPTION
Use `/status/ping` as a more responsive and smaller sized response for the load balancer check