### PR TITLE
Stop duplicating campaigns in background tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,3 +124,4 @@ gem 'memoist'
 gem 'validate_url'
 gem 'sidekiq'
 gem 'sinatra', :require => nil
+gem 'sidekiq-failures'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,6 +414,8 @@ GEM
       json (~> 1.0)
       redis (~> 3.2, >= 3.2.1)
       redis-namespace (~> 1.5, >= 1.5.2)
+    sidekiq-failures (0.4.5)
+      sidekiq (>= 2.16.0)
     simplecov (0.8.2)
       docile (~> 1.1.0)
       multi_json
@@ -539,6 +541,7 @@ DEPENDENCIES
   shoulda
   shoulda-context
   sidekiq
+  sidekiq-failures
   sinatra
   sqlite3
   surveyor!

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 thin:  bundle exec thin start -p $PORT
 delayed_job:  bundle exec rake jobs:work
-sidekiq: bundle exec sidekiq -c 2
+sidekiq: bundle exec sidekiq -c 1

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -51,7 +51,7 @@ class CampaignsController < ApplicationController
   end
 
   def new
-    @campaign = CertificationCampaign.new
+    @campaign = CertificationCampaign.new(jurisdiction: current_user.default_jurisdiction)
   end
 
   def create

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -57,7 +57,7 @@ class CampaignsController < ApplicationController
   def create
     @campaign = current_user.certification_campaigns.create(params[:certification_campaign])
     if @campaign.valid?
-      CertificateFactory::FactoryRunner.perform_async(feed: @campaign.url, user_id: current_user.id, limit: @campaign.limit, campaign: @campaign.name, jurisdiction: @campaign.jurisdiction)
+      CertificateFactory::FactoryRunner.perform_async(feed: @campaign.url, user_id: current_user.id, limit: @campaign.limit, campaign_id: @campaign.id, jurisdiction: @campaign.jurisdiction)
       flash[:notice] = "Campaign queued to run"
       redirect_to campaign_path(@campaign, certificate_level: "all")
     else

--- a/app/models/certificate_generator.rb
+++ b/app/models/certificate_generator.rb
@@ -94,7 +94,7 @@ class CertificateGenerator < ActiveRecord::Base
           .includes(:answers)
           .each {|question| answer question}
 
-    response_set.autocomplete(request["documentationUrl"])
+    response_set.autocomplete(autocomplete_url)
 
     user = determine_user(response_set, create_user)
     response_set.assign_to_user!(user)
@@ -156,6 +156,10 @@ class CertificateGenerator < ActiveRecord::Base
 
   def dataset_url
     dataset.api_url
+  end
+
+  def autocomplete_url
+    request["documentationUrl"]
   end
 
   # the dataset parameters from the request, defaults to {}

--- a/app/models/certificate_generator.rb
+++ b/app/models/certificate_generator.rb
@@ -141,8 +141,10 @@ class CertificateGenerator < ActiveRecord::Base
         user.skip_confirmation_notification!
       end
     end
+  # in case the there was a find or create race
+  rescue ActiveRecord::RecordNotUnique
+    User.find_by_email(contact.email)
   rescue ActiveRecord::RecordInvalid => e
-    # in case the there was a find or create race
     User.find_by_email(contact.email) if e.message =~ /taken/
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,10 @@ class User < ActiveRecord::Base
     end
   end
 
+  def default_jurisdiction
+    super || 'gb'
+  end
+
   # name isn't mandatory on signup, so fall back to email
   def identifier
     name.presence || email.split('@').join(' from ')

--- a/app/views/campaigns/new.html.erb
+++ b/app/views/campaigns/new.html.erb
@@ -13,14 +13,6 @@
   </div>
 
   <div class="control-group">
-    <%= f.label(:limit, "Certificate limit", class: "control-label") %>
-    <div class="controls">
-      <%= f.number_field :limit, min: 0 %>
-      <%= error_message_for(@campaign, :limit) %>
-    </div>
-  </div>
-
-  <div class="control-group">
     <%= f.label(:url, "CKAN atom feed", class: "control-label") %>
     <div class="controls">
       <%= f.text_field :url, class: "span6" %>
@@ -33,6 +25,14 @@
     <div class="controls">
       <%= f.select(:jurisdiction, jurisdiction_options_for_select(@campaign.jurisdiction)) %>
       <%= error_message_for(@campaign, :jurisdiction) %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= f.label(:limit, "Certificate limit (optional)", class: "control-label") %>
+    <div class="controls">
+      <%= f.number_field :limit, min: 0 %>
+      <%= error_message_for(@campaign, :limit) %>
     </div>
   </div>
 

--- a/app/views/campaigns/new.html.erb
+++ b/app/views/campaigns/new.html.erb
@@ -1,7 +1,5 @@
 <% content_for :header_title, "New Campaign" %>
 
-<%#= error_messages_for(@campaign) %>
-
 <%= form_for @campaign, url: campaigns_path, method: :post do |f| %>
 
   <%= hidden_field_tag :version, 2 %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -85,7 +85,7 @@
           <%= missing_responses(generator, "<br /><br />").html_safe %>
         </td>
       <% else %>
-        <td colspan="5">Processing…</td>
+        <td colspan="5">Processing… <%= link_to generator.autocomplete_url, generator.autocomplete_url %></td>
       <% end %>
     </tr>
   <% end %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -27,6 +27,8 @@ end
 
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV['ODC_REDIS_SERVER_URL'] }
+
+  config.failures_default_mode = :all
 end
 
 Sidekiq.configure_client do |config|

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -125,10 +125,11 @@ Given(/^I run the rake task to create certificates$/) do
 end
 
 Given(/^the campaign is created$/) do
+  campaign = CertificationCampaign.find_by_name(@campaign)
   CertificateFactory::Factory.new("feed"=>@url,
       "user_id"=>@api_user.id,
       "limit"=>@limit,
-      "campaign"=>@campaign,
+      "campaign"=>campaign,
       "jurisdiction"=>"cert-generator").build
 end
 

--- a/lib/extra/certificate_factory/certificate.rb
+++ b/lib/extra/certificate_factory/certificate.rb
@@ -5,23 +5,22 @@ module CertificateFactory
       @url = url
       @user = User.find(user_id)
       @dataset_url = options[:dataset_url]
-      @campaign_name = options[:campaign]
+      @campaign = options[:campaign]
       @jurisdiction = options[:jurisdiction] || "gb"
       @create_user = options[:create_user] || true
       @existing_dataset = options[:existing_dataset]
-      @feed_url = options[:feed_url]
     end
 
     def generate
       if existing_certificate?
-        campaign.increment!(:duplicate_count) if campaign
+        @campaign.increment!(:duplicate_count) if @campaign
       else
         generator = CertificateGenerator.create(
           request: {
             documentationUrl: @url
           },
           user: @user,
-          certification_campaign: campaign
+          certification_campaign: @campaign
         )
         generator.sidekiq_delay.generate(@jurisdiction, @create_user, @existing_dataset)
       end
@@ -30,12 +29,6 @@ module CertificateFactory
     def existing_certificate?
       @existing_dataset = Dataset.where(documentation_url: @url).first
       @existing_dataset.try(:certificate).present?
-    end
-
-    def campaign
-      if @campaign_name
-        @campaign ||= CertificationCampaign.where(:user_id => @user.id).find_or_create_by_name_and_url(@campaign_name, @feed_url)
-      end
     end
 
   end

--- a/lib/extra/certificate_factory/factory.rb
+++ b/lib/extra/certificate_factory/factory.rb
@@ -23,7 +23,7 @@ module CertificateFactory
     def build
       each do |item|
         url = get_link(item)
-        CertificateFactory::Certificate.new(url, @user_id, campaign: @campaign, jurisdiction: @jurisdiction, feed_url: @url).generate
+        CertificateFactory::Certificate.new(url, @user_id, campaign: @campaign, jurisdiction: @jurisdiction).generate
       end
     end
 

--- a/lib/extra/certificate_factory/runner.rb
+++ b/lib/extra/certificate_factory/runner.rb
@@ -3,6 +3,9 @@ module CertificateFactory
     include Sidekiq::Worker
 
     def perform(options)
+      if campaign_id = options.delete('campaign_id')
+        options['campaign'] = CertificationCampaign.find(campaign_id)
+      end
       CertificateFactory::Factory.new(options).build
     end
   end
@@ -11,6 +14,9 @@ module CertificateFactory
     include Sidekiq::Worker
 
     def perform(options)
+      if campaign_id = options.delete('campaign_id')
+        options['campaign'] = CertificationCampaign.find(campaign_id)
+      end
       CertificateFactory::CSVFactory.new(options).build
     end
   end

--- a/lib/tasks/certificate_factory.rake
+++ b/lib/tasks/certificate_factory.rake
@@ -18,7 +18,7 @@ task :certificates do
   options = {
     user_id: user.id,
     limit: ENV['LIMIT'],
-    jurisdiction: ENV['JURISDICTION'] || 'gb'
+    jurisdiction: ENV.fetch('JURISDICTION'], 'gb')
   }
   if campaign_name = ENV['CAMPAIGN']
     campaign = user.certification_campaigns.where(name: campaign_name).first_or_create(url: url)

--- a/lib/tasks/certificate_factory.rake
+++ b/lib/tasks/certificate_factory.rake
@@ -18,7 +18,7 @@ task :certificates do
   options = {
     user_id: user.id,
     limit: ENV['LIMIT'],
-    jurisdiction: ENV.fetch('JURISDICTION'], 'gb')
+    jurisdiction: ENV.fetch('JURISDICTION', 'gb')
   }
   if campaign_name = ENV['CAMPAIGN']
     campaign = user.certification_campaigns.where(name: campaign_name).first_or_create(url: url)

--- a/lib/tasks/certificate_factory.rake
+++ b/lib/tasks/certificate_factory.rake
@@ -14,7 +14,7 @@ end
 task :certificates do
   url = ENV['URL']
   csv = ENV['CSV']
-  user = User.find(ENV['USER_ID'])
+  user = User.find(ENV.fetch('USER_ID'))
   options = {
     user_id: user.id,
     limit: ENV['LIMIT'],


### PR DESCRIPTION
Due to threads, transactions and other general evils of parallelism the campaign was getting duplicated.

So before sidekiq jobs start running create the campaign record once and refer to it by id from then on.