### PR TITLE
Remove use of `DelayedModel` extension

### DIFF
--- a/app/models/certification_campaign.rb
+++ b/app/models/certification_campaign.rb
@@ -46,13 +46,12 @@ class CertificationCampaign < ActiveRecord::Base
       end
     else
       certificate_generators.each do |c|
-        dataset = Dataset.find(c.dataset.id)
         jurs = if c.survey
           c.survey.access_code
         else
           jurisdiction
         end
-        run_generator(c.request, jurs, dataset)
+        run_generator(c.request, jurs, c.dataset)
       end
     end
   end

--- a/app/models/certification_campaign.rb
+++ b/app/models/certification_campaign.rb
@@ -82,7 +82,8 @@ class CertificationCampaign < ActiveRecord::Base
 
   def scheduled_rerun
     rerun!
-    self.sidekiq_delay_until(1.day.from_now).scheduled_rerun
+  ensure
+    CertificationCampaignWorker.perform_in(1.day, id)
   end
 
 end

--- a/app/models/certification_campaign.rb
+++ b/app/models/certification_campaign.rb
@@ -77,7 +77,7 @@ class CertificationCampaign < ActiveRecord::Base
         user: user,
         certification_campaign: self)
     end
-    CertificateGeneratorWorker.perform_async(generator.id, jurisdiction, dataset.try(:id))
+    CertificateGeneratorWorker.perform_async(generator.id, jurisdiction, true, dataset.try(:id))
   end
 
   def scheduled_rerun

--- a/app/workers/certificate_generator_worker.rb
+++ b/app/workers/certificate_generator_worker.rb
@@ -1,0 +1,10 @@
+class CertificateGeneratorWorker
+  include Sidekiq::Worker
+
+  def perform(certificate_generator_id, jurisdiction, dataset_id)
+    generator = CertificateGenerator.find(certificate_generator_id)
+    dataset = Dataset.find_by_id dataset_id
+    generator.generate(jurisdiction, true, dataset)
+  end
+
+end

--- a/app/workers/certificate_generator_worker.rb
+++ b/app/workers/certificate_generator_worker.rb
@@ -1,10 +1,10 @@
 class CertificateGeneratorWorker
   include Sidekiq::Worker
 
-  def perform(certificate_generator_id, jurisdiction, dataset_id)
+  def perform(certificate_generator_id, jurisdiction, create_user, dataset_id)
     generator = CertificateGenerator.find(certificate_generator_id)
     dataset = Dataset.find_by_id dataset_id
-    generator.generate(jurisdiction, true, dataset)
+    generator.generate(jurisdiction, create_user, dataset)
   end
 
 end

--- a/app/workers/certification_campaign_worker.rb
+++ b/app/workers/certification_campaign_worker.rb
@@ -1,0 +1,10 @@
+class CertificationCampaignWorker
+  include Sidekiq::Worker
+
+  def perform(id)
+    campaign = CertificationCampaign.find(id)
+    campaign.scheduled_rerun
+  end
+
+end
+

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,29 +1,5 @@
-module Sidekiq::Extensions::Klass
-  alias :sidekiq_delay :delay
-  remove_method :delay
-  alias :sidekiq_delay_for :delay_for
-  remove_method :delay_for
-  alias :sidekiq_delay_until :delay_until
-  remove_method :delay_until
-end
-
-module Sidekiq::Extensions::ActiveRecord
-  alias :sidekiq_delay :delay
-  remove_method :delay
-  alias :sidekiq_delay_for :delay_for
-  remove_method :delay_for
-  alias :sidekiq_delay_until :delay_until
-  remove_method :delay_until
-end
-
-module Sidekiq::Extensions::ActionMailer
-  alias :sidekiq_delay :delay
-  remove_method :delay
-  alias :sidekiq_delay_for :delay_for
-  remove_method :delay_for
-  alias :sidekiq_delay_until :delay_until
-  remove_method :delay_until
-end
+Sidekiq.hook_rails!
+Sidekiq.remove_delay!
 
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV['ODC_REDIS_SERVER_URL'] }

--- a/features/api.feature
+++ b/features/api.feature
@@ -4,6 +4,7 @@ Feature: Open Data Certificate API
   Background:
     Given I want to create a certificate via the API
 
+  @sidekiq_fake
   Scenario: API call returns pending initially
     When I request a certificate via the API
     And I request the status via the API
@@ -15,7 +16,6 @@ Feature: Open Data Certificate API
   Scenario: API call with autocompleting data
     Given my URL autocompletes via DataKitten
     When I request a certificate via the API
-    And the certificate is created
     And I request the results via the API
     Then the API response should return sucessfully
     And my certificate should be published

--- a/features/campaigns.feature
+++ b/features/campaigns.feature
@@ -5,7 +5,6 @@ Feature: Display information about campaigns in UI
     Given I want to create a certificate via the API
     And I apply a campaign "brian"
     And I request a certificate via the API
-    And the certificate is created
     And I request a certificate via the API
     And I am signed in as the API user
 
@@ -35,7 +34,6 @@ Feature: Display information about campaigns in UI
     And I apply a campaign "brian"
     But I miss the field "dataTitle"
     And I request a certificate via the API
-    And the certificate is created
     When I visit the campaign page for "brian"
     Then I should see "3 datasets inspected"
     And I should see "2 datasets added"
@@ -47,7 +45,6 @@ Feature: Display information about campaigns in UI
     And I apply a campaign "brian"
     But I miss the field "dataTitle"
     And I request a certificate via the API
-    And the certificate is created
     When I visit the campaign page for "brian"
     And I click the "Download CSV" link
     Then I should get a CSV file

--- a/features/rerun_whole_campaigns.feature
+++ b/features/rerun_whole_campaigns.feature
@@ -18,7 +18,6 @@ Feature: Rerun campaigns
     And the field "publisherUrl" is missing from my metadata
     And my URL autocompletes via DataKitten
     When I request a certificate via the API
-    And the certificate is created
     And I visit the campaign page for "brian"
     When I add the field "publisherUrl" with the value "http://example.com" to my metadata
     And my URL autocompletes via DataKitten

--- a/features/rerun_whole_campaigns.feature
+++ b/features/rerun_whole_campaigns.feature
@@ -34,13 +34,12 @@ Feature: Rerun campaigns
     Then I should be redirected to the campaign page for "brian"
     And I should see the correct generators
 
-  @sidekiq_fake
   Scenario: Schedule a daily rerun
     Given I have a campaign "brian"
     And that campaign has 5 certificates
     And I visit the campaign page for "brian"
-    And I click "Schedule campaign"
     Then a rerun should be scheduled for tomorrow
+    When I click "Schedule campaign"
 
   Scenario: Rerun campaign button shows correct numbers
     Given I have a campaign "brian"

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -41,7 +41,7 @@ end
 Given(/^I request (\d+) certificates with the campaign "(.*?)"$/) do |num, tag|
   num.to_i.times do |i|
     steps %Q{
-      Given I want to create a certificate via the API
+      Given I want to create a certificate via the API with the URL "http://example.com/dataset#{i}"
       And I apply a campaign "#{tag}"
       And I request a certificate via the API
     }
@@ -51,7 +51,6 @@ end
 Given(/^I create a certificate via the API$/) do
   steps %Q{
     When I request a certificate via the API
-    And the certificate is created
     And I request the results via the API
     Then the API response should return sucessfully
   }
@@ -88,7 +87,7 @@ When(/^I request a certificate via the API$/) do
 end
 
 When(/^the certificate is created$/) do
-  generator = CertificateGenerator.all.select { |g| g.request["documentationUrl"] == @documentationURL }.first
+  generator = CertificateGenerator.all.find { |g| g.request["documentationUrl"] == @documentationURL }
   generator.generate(@body[:jurisdiction], @body[:create_user])
 end
 

--- a/features/step_definitions/campaign_steps.rb
+++ b/features/step_definitions/campaign_steps.rb
@@ -34,6 +34,7 @@ end
 
 Given(/^I have a campaign "(.*?)"$/) do |name|
   @campaign = name
+  @certification_campaign = CertificationCampaign.where(user_id: @api_user.id).find_or_create_by_name(name)
 end
 
 Given(/^that campaign has (\d+) certificates?$/) do |num|
@@ -58,7 +59,7 @@ Then(/^the generators should be queued for rerun$/) do
 end
 
 Then(/^a rerun should be scheduled for tomorrow$/) do
-  assert_equal Date.today + 1.day, DateTime.strptime(Sidekiq::Extensions::DelayedModel.jobs.last["at"].to_s, "%s").to_date
+  CertificationCampaignWorker.expects(:perform_in).with(1.day, @certification_campaign.id)
 end
 
 When(/^I should be redirected to the campaign page for "(.*?)"$/) do |campaign|

--- a/features/step_definitions/campaign_steps.rb
+++ b/features/step_definitions/campaign_steps.rb
@@ -44,7 +44,6 @@ Given(/^that campaign has (\d+) certificates?$/) do |num|
       Given I want to create a certificate via the API with the URL "http://data.example.com/datasets/#{i}"
       And I apply a campaign "#{@campaign}"
       And I request a certificate via the API
-      And the certificate is created
     }
   end
 end

--- a/lib/extra/certificate_factory/certificate.rb
+++ b/lib/extra/certificate_factory/certificate.rb
@@ -23,7 +23,7 @@ module CertificateFactory
             user: @user,
             certification_campaign: @campaign)
         end
-        CertificateGeneratorWorker.perform_async(generator.id, @jurisdiction, @existing_dataset.try(:id))
+        CertificateGeneratorWorker.perform_async(generator.id, @jurisdiction, true, @existing_dataset.try(:id))
       end
     end
 

--- a/test/functional/datasets_controller_test.rb
+++ b/test/functional/datasets_controller_test.rb
@@ -400,7 +400,6 @@ class DatasetsControllerTest < ActionController::TestCase
     dataset = certificate.dataset
     http_auth FactoryGirl.create(:user)
 
-    CertificateGenerator.any_instance.stubs(:delay).returns CertificateGenerator.new
     CertificateGenerator.any_instance.expects(:generate).once
 
     assert_difference "CertificateGenerator.count", 1 do
@@ -431,7 +430,6 @@ class DatasetsControllerTest < ActionController::TestCase
     load_custom_survey 'cert_generator.rb'
     http_auth FactoryGirl.create(:user)
 
-    CertificateGenerator.any_instance.stubs(:delay).returns CertificateGenerator.new
     CertificateGenerator.any_instance.expects(:generate).once
 
     assert_difference "CertificateGenerator.count", 1 do
@@ -448,7 +446,7 @@ class DatasetsControllerTest < ActionController::TestCase
     user = FactoryGirl.create(:user)
     http_auth user
 
-    CertificateGenerator.any_instance.stubs(:delay).returns stub(generate: nil)
+    CertificateGeneratorWorker.expects(:perform_async).returns(nil)
 
     assert_difference "CertificationCampaign.count", 1 do
       post :create, {
@@ -471,7 +469,7 @@ class DatasetsControllerTest < ActionController::TestCase
     other_user = FactoryGirl.create(:user)
     http_auth generating_user
 
-    CertificateGenerator.any_instance.stubs(:delay).returns stub(generate: nil)
+    CertificateGeneratorWorker.expects(:perform_async).returns(nil)
 
     assert_difference "CertificationCampaign.count", 1 do
       post :create, jurisdiction: 'cert-generator',


### PR DESCRIPTION
it both doesn't work and is recommended against in the [sidekiq documentation](https://github.com/mperham/sidekiq/wiki/Delayed-extensions#activerecord)

All cases of generating a certificate in the background are now done via a sidekiq worker. Only primitive ruby types are serialized onto the queue.