### PR TITLE
Allow reruning of campaigns

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -125,16 +125,12 @@ module ApplicationHelper
     @devise_mapping ||= Devise.mappings[:user]
   end
 
-  def check_mark
-    "&check;".html_safe
-  end
-
-  def cross_mark
-    "&cross;".html_safe
+  def icon_mark(name)
+    content_tag(:i, '', class: "icon-#{name}")
   end
 
   def boolean_mark(value)
-    value ? check_mark : cross_mark
+    value ? icon_mark("ok") : icon_mark("remove")
   end
 
   def atom_datetime(value)

--- a/app/models/certificate_generator.rb
+++ b/app/models/certificate_generator.rb
@@ -152,6 +152,10 @@ class CertificateGenerator < ActiveRecord::Base
     certificate.try(:published?)
   end
 
+  def valid_urls?
+    response_set.all_urls_resolve?
+  end
+
   def response_errors
     response_set.response_errors
   end

--- a/app/models/certification_campaign.rb
+++ b/app/models/certification_campaign.rb
@@ -42,16 +42,11 @@ class CertificationCampaign < ActiveRecord::Base
         url = factory.get_link(item)
         existing_generator = certificate_generators.select { |g| g.request["documentationUrl"] == url }.first
         request = existing_generator.try(:request) || build_request(url)
-        run_generator(request, certificate_generators.first.survey.access_code, existing_generator.try(:dataset))
+        run_generator(request, existing_generator.try(:dataset))
       end
     else
       certificate_generators.each do |c|
-        jurs = if c.survey
-          c.survey.access_code
-        else
-          jurisdiction
-        end
-        run_generator(c.request, jurs, c.dataset)
+        run_generator(c.request, c.dataset)
       end
     end
   end
@@ -70,7 +65,7 @@ class CertificationCampaign < ActiveRecord::Base
     @limit.to_i unless @limit.blank?
   end
 
-  def run_generator(request, jurisdiction, dataset)
+  def run_generator(request, dataset)
     generator = CertificateGenerator.transaction do
       CertificateGenerator.create!(
         request: request,

--- a/app/models/certification_campaign.rb
+++ b/app/models/certification_campaign.rb
@@ -72,13 +72,22 @@ class CertificationCampaign < ActiveRecord::Base
         user: user,
         certification_campaign: self)
     end
-    CertificateGeneratorWorker.perform_async(generator.id, jurisdiction, true, dataset.try(:id))
+    CertificateGeneratorWorker.perform_async(generator.id, determine_jurisdiction, true, dataset.try(:id))
   end
 
   def scheduled_rerun
     rerun!
   ensure
     CertificationCampaignWorker.perform_in(1.day, id)
+  end
+
+  def determine_jurisdiction
+    [
+      jurisdiction.presence,
+      certificate_generators.first.try(:survey).try(:access_code),
+      user.try(:default_jurisdiction).presence,
+      'gb'
+    ].compact.first
   end
 
 end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -510,6 +510,7 @@ class ResponseSet < ActiveRecord::Base
   end
 
   def autocomplete(url)
+    return unless url.present?
     update_responses({documentationUrl: url})
     responses.update_all(autocompleted: false)
     update_attribute('kitten_data', nil)

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -514,9 +514,7 @@ class ResponseSet < ActiveRecord::Base
     responses.update_all(autocompleted: false)
     update_attribute('kitten_data', nil)
 
-    code = resolve_url(url)
-
-    if code == 200
+    if ODIBot.new(url).valid?
       create_kitten_data(url: url)
       update_responses(kitten_data.fields)
     end
@@ -528,12 +526,6 @@ class ResponseSet < ActiveRecord::Base
 
   def description
     kitten_data.get(:description) if has_kitten_data?
-  end
-
-  def resolve_url(url)
-    if url =~ /^#{URI::regexp}$/
-      ODIBot.new(url).response_code rescue nil
-    end
   end
 
   # finds the string value for a given response_identifier

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -31,9 +31,6 @@
   <thead>
   <tr>
     <th>
-      Success
-    </th>
-    <th>
       Published
     </th>
     <th>
@@ -58,11 +55,8 @@
   <tbody>
   <% @generators.each do |generator| %>
     <tr>
-      <td>
-        <%= boolean_mark(generator.completed?) %>
-      </td>
-      <td>
-        <%= boolean_mark(generator.published?) %>
+      <td style="text-align: center">
+        <%= generator.completed? ? boolean_mark(generator.published?) : icon_mark("time") %>
       </td>
       <% if generator.completed? %>
         <td>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -91,7 +91,9 @@
   <% end %>
   </tbody>
 </table>
-<%= paginate @generators %>
+<div class='omit-in-print'>
+  <%= paginate @generators %>
+</div>
 
 <div class='omit-in-print'>
   <%= link_to 'Download CSV', format: "csv" %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -48,6 +48,9 @@
       User
     </th>
     <th>
+      URLs valid
+    </th>
+    <th>
       Missing responses
     </th>
   </tr>
@@ -80,6 +83,9 @@
         <% end %>
         <td class='omit-in-print'>
             <%= generator.dataset.user_email %>
+        </td>
+        <td>
+          <%= boolean_mark(generator.valid_urls?) %>
         </td>
         <td>
           <%= missing_responses(generator, "<br /><br />").html_safe %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -1,6 +1,10 @@
 <% content_for :header_title, "Certification campaign: #{@campaign.name}" %>
 
 <h3><%= report_heading(@certificate_level) %></h3>
+<p>
+Feed URL: <%= link_to truncate(@campaign.url, length: 80), @campaign.url %>
+</p>
+
 <div class='schedule-controls omit-in-print'>
   <%= button_to "Rerun campaign", campaign_rerun_path(@campaign), method: 'post', class: 'btn' %>
   <%= button_to "Schedule campaign", campaign_scheduled_rerun_path(@campaign), method: 'post', class: 'btn' %>

--- a/features/step_definitions/campaign_steps.rb
+++ b/features/step_definitions/campaign_steps.rb
@@ -34,7 +34,9 @@ end
 
 Given(/^I have a campaign "(.*?)"$/) do |name|
   @campaign = name
-  @certification_campaign = CertificationCampaign.where(user_id: @api_user.id).find_or_create_by_name(name)
+  @certification_campaign = CertificationCampaign.where(user_id: @api_user.id).find_or_create_by_name(name) do |campaign|
+    campaign.jurisdiction = 'cert-generator'
+  end
 end
 
 Given(/^that campaign has (\d+) certificates?$/) do |num|

--- a/test/unit/certificate_generator_test.rb
+++ b/test/unit/certificate_generator_test.rb
@@ -286,7 +286,7 @@ class CertificateGeneratorTest < ActiveSupport::TestCase
   end
 
   test "latest generator gets tagged as such" do
-    campaign = CertificationCampaign.create(name: "foobar")
+    campaign = CertificationCampaign.create(name: "foobar", jurisdiction: "cert-generator")
 
     dataset = {
       dataTitle: 'The title',

--- a/test/unit/odibot_test.rb
+++ b/test/unit/odibot_test.rb
@@ -54,6 +54,11 @@ class ODIBotTest < ActiveSupport::TestCase
     assert bot.is_http_url?
   end
 
+  test "adapts unsafe characters to escaped equivlent" do
+    bot = ODIBot.new("http://example.org/dataset/dataset .csv")
+    assert_equal URI.parse("http://example.org/dataset/dataset%20.csv"), bot.uri
+  end
+
   test "exception raising uri is invalid" do
     bot = ODIBot.new("!:!:")
     refute bot.is_http_url?


### PR DESCRIPTION
Refactor backgrounding of certificate processing jobs to use Sidekiq workers instead of `DelayedModel` extensions as they didn't work with serialized instances.

Allow rerunning of campaigns including ones that hadn't been successfully run as the jurisdiction is now saved on the campaign.