### PR TITLE
Fix spelling mistakes and state transition errors

### DIFF
--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -1726,7 +1726,7 @@ a.transfer {
 .status-badge-archived{
   background-image:url(/assets/status/archived.png);
 }
-.status-badge-superceded{
+.status-badge-superseded{
   background-image:url(/assets/status/archived.png);
 }
 

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -43,7 +43,7 @@ class SurveyorController < ApplicationController
         end
       end
 
-    elsif @response_set.survey.superceded?
+    elsif @response_set.survey.superseded?
       latest_survey = Survey.newest_survey_for_access_code(params[:survey_code])
       unless latest_survey.nil?
         switch_survey(latest_survey)
@@ -206,7 +206,7 @@ class SurveyorController < ApplicationController
     attrs['survey_id'] = survey.id
     response_set = @response_set
     create_new_response_set(attrs)
-    response_set.supercede!
+    response_set.supersede!
   end
 
 end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -107,7 +107,7 @@ class ResponseSet < ActiveRecord::Base
     end
 
     event :supersede do
-      transitions from: [:draft, :published], to: :superseded
+      transitions from: [:draft, :published, :superseded], to: :superseded
     end
   end
 

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -96,7 +96,7 @@ class ResponseSet < ActiveRecord::Base
 
     state :archived
 
-    state :superceded
+    state :superseded
 
     event :publish do
       transitions from: :draft, to: :published, guard: :all_mandatory_questions_complete?
@@ -106,8 +106,8 @@ class ResponseSet < ActiveRecord::Base
       transitions from: :published, to: :archived
     end
 
-    event :supercede do
-      transitions from: [:draft, :published], to: :superceded
+    event :supersede do
+      transitions from: [:draft, :published], to: :superseded
     end
   end
 

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -92,7 +92,7 @@ class Survey < ActiveRecord::Base
     meta
   end
 
-  def superceded?
+  def superseded?
     !(self.id == Survey.newest_survey_for_access_code(access_code).try(:id))
   end
 

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -128,7 +128,7 @@ cs:
       draft: Draft
       published: Published
       archived: Archived
-      superceded: Superceded
+      superseded: Superseded
     expiring_states:
       expired: Expired
       expiring: 'Expires in %{days} days'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,7 +128,7 @@ en:
       draft: Draft
       published: Published
       archived: Archived
-      superceded: Superceded
+      superseded: Superseded
     expiring_states:
       expired: Expired
       expiring: 'Expires in %{days} days'

--- a/db/migrate/20150903110030_rename_superseded_state.rb
+++ b/db/migrate/20150903110030_rename_superseded_state.rb
@@ -1,0 +1,8 @@
+class RenameSupersededState < ActiveRecord::Migration
+  def up
+    execute("update response_sets set aasm_state = 'superseded' where aasm_state = 'superceded'")
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150702134537) do
+ActiveRecord::Schema.define(:version => 20150903110030) do
 
   create_table "answers", :force => true do |t|
     t.integer  "question_id"

--- a/test/unit/response_set_test.rb
+++ b/test/unit/response_set_test.rb
@@ -141,7 +141,7 @@ class ResponseSetTest < ActiveSupport::TestCase
     new_survey.survey_version = 1
     new_survey.save
 
-    assert old_survey.superceded?, 'survey should be superceded'
+    assert old_survey.superseded?, 'survey should be superseded'
 
     response_set = nil
     assert_difference 'ResponseSet.count', 1 do

--- a/test/unit/survey_test.rb
+++ b/test/unit/survey_test.rb
@@ -2,21 +2,21 @@ require 'test_helper'
 
 class SurveyTest < ActiveSupport::TestCase
 
-  test "#superceded? returns false when survey is most recent version" do
+  test "#superseded? returns false when survey is most recent version" do
     survey = FactoryGirl.create :survey # version 0
     survey = FactoryGirl.create :survey, access_code: survey.access_code, survey_version: nil # version 1
 
     assert Survey.newest_survey_for_access_code(survey.access_code).try(:survey_version) == 1
-    assert_false survey.superceded?
+    assert_false survey.superseded?
   end
 
-  test "#superceded? returns true when survey is not most recent version" do
+  test "#superseded? returns true when survey is not most recent version" do
     survey = FactoryGirl.create :survey # version 0
     survey = FactoryGirl.create :survey, access_code: survey.access_code, survey_version: nil # version 1
     FactoryGirl.create :survey, access_code: survey.access_code, survey_version: nil # version 2
 
     assert Survey.newest_survey_for_access_code(survey.access_code).try(:survey_version) == 2
-    assert survey.superceded?
+    assert survey.superseded?
   end
 
   test "#status_incremented? returns true when the previous survey has a lower status" do


### PR DESCRIPTION
  * Supersede was spelt wrong, correct it before things get worse
  * Stop errors from double transitioning when switching surveys to different jurisdictions.