### PR TITLE
Allow starting a questionnaire in another language

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,8 +14,7 @@ class ApplicationController < ActionController::Base
 
   # maintain the locale param on any urls
   def default_url_options(options={})
-    # { :locale => I18n.locale }
-    {}
+    { locale: nil }
   end
 
   def after_sign_in_path_for(resource)

--- a/app/views/surveyor/edit.html.haml
+++ b/app/views/surveyor/edit.html.haml
@@ -73,7 +73,7 @@
 
 
           .documentation-url
-            - question = @survey.questions.find_by_reference_identifier("documentationURL")
+            - question = @survey.documentation_url
             %label
               = question.heading
             .row-fluid

--- a/app/views/surveyor/start.html.haml
+++ b/app/views/surveyor/start.html.haml
@@ -44,7 +44,7 @@
               %a{href: about_url} Read more about Open Data Certificates
 
         = semantic_form_for [surveyor, :start, @response_set] do |f|
-          - question = @survey.questions.find_by_reference_identifier("documentationURL")
+          - question = @survey.documentation_url
           = f.label :documentation_url, question.heading
 
           .row-fluid

--- a/test/functional/surveyor_controller_test.rb
+++ b/test/functional/surveyor_controller_test.rb
@@ -145,7 +145,7 @@ class SurveyorControllerTest < ActionController::TestCase
     survey = @response_set.survey
     section = FactoryGirl.create(:survey_section)
     survey.sections << section
-    question = FactoryGirl.create(:question, reference_identifier: "documentationURL", survey_section: section)
+    question = FactoryGirl.create(:question, reference_identifier: "documentationUrl", survey_section: section)
     question.answers << FactoryGirl.create(:answer) 
 
     sign_in @response_set.user


### PR DESCRIPTION
The localisation helpers were adding `?locale=val` to urls which because some of the javascript constructs urls by appending `.json` :sob: causes issues.

This is a temporary fix as the locale parameter isn't needed while translation is only controlled by a stored value on `ResponseSet`