### PR TITLE
Fix labels not being clickable in the login form

### DIFF
--- a/app/views/devise/sessions/_form.html.haml
+++ b/app/views/devise/sessions/_form.html.haml
@@ -2,7 +2,7 @@
 - remote ||= false
 - form_id ||= 'sign_in_user_form'
 
-= form_for(resource, :as => resource_name, :url => session_path(resource_name), :remote => remote, :format => :json, :html => { :id => form_id, :class => 'sign_in_user', 'data-remote-error-message' => t('errors.server_error')}) do |f|
+= form_for(resource, :as => resource_name, :url => session_path(resource_name), :remote => remote, :format => :json, :namespace => form_id, :html => { :id => form_id, :class => 'sign_in_user', 'data-remote-error-message' => t('errors.server_error')}) do |f|
   = hidden_field_tag :form_id, form_id
   .form-errors.sign_in_user_form_errors
     - if errors

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -207,8 +207,8 @@ end
 
 Given(/^I am signed in as the API user$/) do
   visit '/users/sign_in'
-  first('#main #user_email').set("api@example.com")
-  first('#main #user_password').set("password")
+  first('#main #sign_in_user_form_user_email').set("api@example.com")
+  first('#main #sign_in_user_form_user_password').set("password")
   first('#main .btn').click
 end
 

--- a/features/step_definitions/certificate_steps.rb
+++ b/features/step_definitions/certificate_steps.rb
@@ -7,8 +7,8 @@ end
 When(/^I am signed in as "(.*?)"$/) do |email|
   @user = get_user(email)
   visit '/users/sign_in'
-  first('#main #user_email').set(email)
-  first('#main #user_password').set("password")
+  first('#main #sign_in_user_form_user_email').set(email)
+  first('#main #sign_in_user_form_user_password').set("password")
   first('#main .btn').click
 end
 


### PR DESCRIPTION
This was only an issue when multiple form partials are
included on the page due to clashing IDs.