### PR TITLE
Add parallel testing to the test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development do
   gem 'ruby-prof'
   gem 'rails-footnotes', '>= 3.7.9'
   gem 'rubyXL'
+  gem 'parallel_tests'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,9 @@ GEM
       rack (~> 1.2)
     open_uri_redirections (0.1.4)
     orm_adapter (0.5.0)
+    parallel (1.6.1)
+    parallel_tests (1.7.0)
+      parallel
     polyamorous (0.6.4)
       activerecord (>= 3.0)
     polyglot (0.3.5)
@@ -556,6 +559,7 @@ DEPENDENCIES
   mocha
   mustache (= 0.99.4)
   mysql2
+  parallel_tests
   pry
   pry-remote
   rabl (~> 0.6.13)

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rake parallel:test && rake parallel:features

--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rake parallel:test && rake parallel:features
+rake parallel:test parallel:features

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ end
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
-require 'parallel_tests/test/runtime_logger'
+require 'parallel_tests/test/runtime_logger' if Rails.env.development?
 
 require 'factory_girl'
 require 'vcr'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ end
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'parallel_tests/test/runtime_logger'
 
 require 'factory_girl'
 require 'vcr'


### PR DESCRIPTION
This adds the ability to test in parallel without impacting any of the normal test procedure. Use it if you want.

Follow the simple 3 step setup described here: https://github.com/grosser/parallel_tests, then run `./bin/test`.

Brings the entire test suite down to around 2 minutes on my machine.