### PR TITLE
Locale switching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ group :development do
   gem 'rails-footnotes', '>= 3.7.9'
   gem 'rubyXL'
   gem 'parallel_tests'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,12 @@ GEM
     bcrypt (3.1.7)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     builder (3.0.4)
     cancan (1.6.10)
     capybara (2.4.1)
@@ -130,6 +136,7 @@ GEM
       json
       json-schema
       rest-client
+    debug_inspector (0.0.2)
     delayed-plugins-airbrake (1.1.0)
       airbrake
       delayed_job
@@ -522,6 +529,8 @@ DEPENDENCIES
   aasm
   airbrake
   alternate_rails!
+  better_errors
+  binding_of_caller
   cancan
   coffee-rails (~> 3.2.1)
   coveralls

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 //= require polyfill
 //= require skroller
 //= require typeahead
+//= require url
 
 //= require admin
 //= require campaigns
@@ -261,11 +262,15 @@ $(document).ready(function($){
     $(this).addClass('disabled');
     $(this).removeClass('error');
     $(this).popover('show');
+
     var form = $(this.form);
+    var formUrl = new Url(form.attr('action'));
+    formUrl.path = formUrl.path + ".json";
+
     $.ajax({
-      type: 'POST',
+      type: 'PUT',
       cache: false,
-      url: form.attr('action') + ".json",
+      url: formUrl.toString(),
       data: form.serialize(),
       success: function(data) {
         window.location.replace(data.survey_path)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,14 +5,10 @@ class ApplicationController < ActionController::Base
 
   helper_method :after_sign_in_path_for
 
-  # pick the locale from ?locale=X in the url,  a prettier
-  # solution might be used down the line, maybe depending
-  # on the ui or user preferences maybe.
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale
   end
 
-  # maintain the locale param on any urls
   def default_url_options(options={})
     { locale: I18n.locale }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   # maintain the locale param on any urls
   def default_url_options(options={})
-    { locale: nil }
+    { locale: I18n.locale }
   end
 
   def after_sign_in_path_for(resource)

--- a/app/controllers/locale_controller.rb
+++ b/app/controllers/locale_controller.rb
@@ -1,0 +1,17 @@
+class LocaleController < ApplicationController
+
+  def redirect_to_locale
+    redirect_to request.fullpath.gsub(%r{\A/(.*)}, "/#{locale_for_redirect}/\\1")
+  end
+
+  private
+
+  def locale_for_redirect
+    if user_signed_in?
+      current_user.preferred_locale
+    else
+      I18n.default_locale
+    end
+  end
+
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -18,7 +18,7 @@ class RegistrationsController < Devise::RegistrationsController
 
   protected
   def after_update_path_for(resource)
-    dashboard_path
+    dashboard_path(locale: resource.preferred_locale)
   end
 
   def campaigns

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -88,9 +88,11 @@ module ApplicationHelper
   end
 
   def is_active_menu_link?(link)
-    # fudged method to return 'true' the first time it's called, and then 'false' every time after that, to fake an 'active' menu item
-    # TODO: write the code to calculate whether a menu item is active
-    Rails.application.routes.recognize_path(link[:path]) == Rails.application.routes.recognize_path(request.env['REQUEST_PATH'])
+    if request.env['REQUEST_PATH'].present?
+      Rails.application.routes.recognize_path(link[:path]) == Rails.application.routes.recognize_path(request.env['REQUEST_PATH'])
+    else
+      false
+    end
   end
 
   def body_class

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -112,6 +112,13 @@ module ApplicationHelper
     options_for_select([[t('response_set.choose_jurisdiction'), nil]] + surveys.map{|s|[s.complete_title, s.access_code]}, default)
   end
 
+  def locale_options_for_select(selected=nil)
+    locales = I18n.available_locales.each_with_object({}) do |locale, memo|
+      memo[t("locales.#{locale}")] = locale
+    end
+    options_for_select(locales, selected)
+  end
+
   # devise mapping
   def resource_name
     :user

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -88,9 +88,9 @@ module ApplicationHelper
   end
 
   def is_active_menu_link?(link)
-    if request.env['REQUEST_PATH'].present?
+    begin
       Rails.application.routes.recognize_path(link[:path]) == Rails.application.routes.recognize_path(request.env['REQUEST_PATH'])
-    else
+    rescue ActionController::RoutingError
       false
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,7 +81,7 @@ module ApplicationHelper
       { link_text: t('menu.my_certificates'), path: dashboard_path, requires_signed_in_user: true },
       { link_text: t('menu.browse_all_certificates'), path: datasets_path },
       { link_text: t('menu.discussion'), path: discussion_path },
-      { link_text: t('menu.about'), path: about_path },
+      { link_text: t('menu.about'), path: about_page_path },
       { link_text: t('menu.admin'), path: admin_path, requires_signed_in_user: true, requires_admin_user: true}
     ]
     render partial: 'layouts/main_menu_navigation_list_item', collection: links, as: :link
@@ -161,10 +161,11 @@ module ApplicationHelper
     end
   end
 
-  def example_dataset
-    if cert = Certificate.published.current.attained_level(:pilot).first
-      cert.dataset
-    end
+  def example_certificate_link
+    cert = Certificate.published.current.attained_level(:pilot).first
+    return '' unless cert.present?
+
+    link_to('See an example certificate', dataset_latest_certificate_path(cert.dataset), :class => ['btn', 'btn-large'])
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -165,7 +165,7 @@ module ApplicationHelper
     cert = Certificate.published.current.attained_level(:pilot).first
     return '' unless cert.present?
 
-    link_to('See an example certificate', dataset_latest_certificate_path(cert.dataset), :class => ['btn', 'btn-large'])
+    link_to('See an example certificate', dataset_latest_certificate_path(I18n.locale, cert.dataset), :class => ['btn', 'btn-large'])
   end
 
   private

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -200,7 +200,7 @@ class Certificate < ActiveRecord::Base
 
   def url(options={})
     urlgen = Rails.application.routes.url_helpers
-    options = options.merge(host: OpenDataCertificate.hostname)
+    options = options.merge(host: OpenDataCertificate.hostname, locale: I18n.locale)
     if latest?
       urlgen.dataset_latest_certificate_url(self.dataset, options)
     else

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -38,6 +38,10 @@ class Claim < ActiveRecord::Base
     end
   end
 
+  def locale
+    'en'
+  end
+
   def transfer_dataset!
     dataset.change_owner!(initiating_user)
   end

--- a/app/models/concerns/badges.rb
+++ b/app/models/concerns/badges.rb
@@ -19,11 +19,11 @@ module Badges
   end
 
   def badge_url
-    urlgen.badge_dataset_latest_certificate_path(dataset.id, format: 'png')
+    urlgen.badge_dataset_latest_certificate_path(dataset.id, format: 'png', locale: I18n.locale)
   end
 
   def embed_url
-    urlgen.badge_dataset_latest_certificate_path(dataset.id, format: 'js')
+    urlgen.badge_dataset_latest_certificate_path(dataset.id, format: 'js', locale: I18n.locale)
   end
 
   private

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -133,7 +133,7 @@ class Dataset < ActiveRecord::Base
   end
 
   def api_url
-    Rails.application.routes.url_helpers.dataset_url(self, format: :json, host: OpenDataCertificate.hostname)
+    Rails.application.routes.url_helpers.dataset_url(self, format: :json, host: OpenDataCertificate.hostname, locale: I18n.locale)
   end
 
   def change_owner!(user)

--- a/app/models/embed_stat.rb
+++ b/app/models/embed_stat.rb
@@ -35,7 +35,7 @@ class EmbedStat < ActiveRecord::Base
 
   def dataset_path
     if dataset
-      Rails.application.routes.url_helpers.dataset_url(dataset, host: OpenDataCertificate.hostname)
+      Rails.application.routes.url_helpers.dataset_url(dataset, host: OpenDataCertificate.hostname, locale: I18n.locale)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ActiveRecord::Base
   has_many :received_claims, class_name: 'Claim', foreign_key: 'user_id'
   has_many :certification_campaigns
 
-  attr_accessible :name, :short_name, :email, :password, :password_confirmation, :default_jurisdiction, :organization, :agreed_to_terms
+  attr_accessible :name, :short_name, :email, :password, :password_confirmation, :default_jurisdiction, :organization, :agreed_to_terms, :preferred_locale
 
   before_save :ensure_authentication_token
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ActiveRecord::Base
   before_save :ensure_authentication_token
 
   validates :agreed_to_terms, acceptance: {accept: true}, allow_nil: true
+  validates :preferred_locale, inclusion: {in: I18n.available_locales.map(&:to_s)}
 
   def ensure_authentication_token
     if authentication_token.blank?

--- a/app/views/claim_mailer/notify_of_approval.text.erb
+++ b/app/views/claim_mailer/notify_of_approval.text.erb
@@ -1,1 +1,1 @@
-<%=t '.message', title: @claim.dataset.title, url: dataset_url(@claim.dataset) %>
+<%=t '.message', title: @claim.dataset.title, url: dataset_url(@claim.locale, @claim.dataset) %>

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -16,6 +16,6 @@
   .form-field
     = f.label :agreed_to_terms do
       = f.check_box :agreed_to_terms
-      = t('authentication.agree_to_terms', terms_link: link_to(t('authentication.terms'), terms_path)).html_safe
+      = t('authentication.agree_to_terms', terms_link: link_to(t('authentication.terms'), terms_page_path)).html_safe
 
   = f.submit t("authentication.sign_up"), :class => 'btn btn-primary'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -22,6 +22,9 @@
     = f.label :default_jurisdiction
     = f.select(:default_jurisdiction, jurisdiction_options_for_select(resource.default_jurisdiction))
   .form-field
+    = f.label :preferred_locale
+    = f.select(:preferred_locale, locale_options_for_select(resource.preferred_locale))
+  .form-field
     = f.label :password
     %i= t("authentication.new_password_info")
     = f.password_field :password, :autocomplete => "off", :class => 'span8'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -31,7 +31,7 @@
   .form-field.check_box
     = f.label :agreed_to_terms do
       = f.check_box :agreed_to_terms
-      = t('authentication.agree_to_terms', terms_link: link_to(t('authentication.terms'), terms_path)).html_safe
+      = t('authentication.agree_to_terms', terms_link: link_to(t('authentication.terms'), terms_page_path)).html_safe
   .form-field
     = f.label :current_password
     %i= t("authentication.current_password_info")

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -57,15 +57,13 @@
         %iframe{width: 560, height: 315, src: 'https://www.youtube.com/embed/_k5pQxeQq9w', frameborder: 0, allowfullscreen: 'allowfullscreen'}
     .span6.homepage-about-content
       %h2.about-certificate
-        -#= link_to t('homepage.about_certificate.title'), certificates_path #TODO: Commented browse certificate functionality
-        = link_to t('homepage.about_certificate.title'), '/about' #TODO: Commented browse certificate functionality
+        = link_to t('homepage.about_certificate.title'), about_page_path
       %p.about-certificate= t('homepage.about_certificate.description')
-      -#= link_to t('homepage.about_certificate.link'), certificates_path, class: ['about-certificate'] #TODO: Commented browse certificate functionality
-      = link_to t('homepage.about_certificate.link'), '/about', class: ['about-certificate'] #TODO: Commented browse certificate functionality
+      = link_to t('homepage.about_certificate.link'), about_page_path, class: ['about-certificate']
       %h2.about-odi
-        = link_to t('homepage.about_odi.title'), '/contact'
+        = link_to t('homepage.about_odi.title'), contact_page_path
       %p.about-odi= t('homepage.about_odi.description', odi_name_link: link_to(t('homepage.about_odi.odi_name'), 'http://theodi.org')).html_safe
-      = link_to t('homepage.about_odi.link'), '/contact', class: ['about-odi']
+      = link_to t('homepage.about_odi.link'), contact_page_path, class: ['about-odi']
 
 
 #international-reach{style: 'visibility:hidden;height:500px;'}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,7 +24,7 @@
       #topbar.navbar.navbar-inverse.navbar-static-top
         .container
           .navbar-inner
-            %a.brand{:href => "/"}
+            %a.brand{:href => root_path}
               - if content_for? :nav_brand
                 = yield :nav_brand
               - else
@@ -79,7 +79,7 @@
               %li
                 = link_to t('footmenu.terms'), '/terms'
               %li
-                = link_to t('footmenu.privacy'), '/privacy-policy'
+                = link_to t('footmenu.privacy'), privacy_policy_path
               %li
                 = link_to t('footmenu.cookies'), '/cookie-policy'
               %li

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,7 +32,7 @@
             %ul.nav.pull-right
               =render 'shared/auth_bar'
             %span.label{:style => "margin-top: 10px;"}
-              =link_to 'BETA', contact_url
+              =link_to 'BETA', contact_page_url
       #mainnav.navbar.navbar-static-top
         .container
           .navbar-inner
@@ -58,7 +58,7 @@
           %h1
             %a{:href => "http://www.theodi.org"}= t('footmenu.odi_name')
           %p
-            = link_to "#{t('footmenu.odi_name')}, 65 Clifton Street, London EC2A 4JE", 'http://www.theodi.org/contact'
+            = link_to "#{t('footmenu.odi_name')}, 65 Clifton Street, London EC2A 4JE", contact_page_path
 
           %p
             %a{:href => "mailto:info@theodi.org"} info@theodi.org
@@ -77,15 +77,15 @@
           %nav
             %ul.pull-right
               %li
-                = link_to t('footmenu.terms'), '/terms'
+                = link_to t('footmenu.terms'), terms_page_path
               %li
                 = link_to t('footmenu.privacy'), privacy_policy_path
               %li
-                = link_to t('footmenu.cookies'), '/cookie-policy'
+                = link_to t('footmenu.cookies'), cookie_policy_path
               %li
-                = link_to t('footmenu.about'), '/about'
+                = link_to t('footmenu.about'), about_page_path
               %li
-                = link_to t('footmenu.get_in_touch'), '/contact'
+                = link_to t('footmenu.get_in_touch'), contact_page_path
 
           %p.rss.pull-right
             - if content_for? :rss_feed

--- a/app/views/pages/about.html.haml
+++ b/app/views/pages/about.html.haml
@@ -4,7 +4,8 @@
   .span8
     %h1 Just one thing before we begin… <strong>thank you</strong>!
 
-    %h2 When people have better access to open data, they can make insightful decisions and innovate to improve society, their environment, our economies, and change the world with their ideas. That’s what we aim for in <a href="http://www.theodi.org/about">our mission</a>. Your effort helps everyone.
+    %h2
+      When people have better access to open data, they can make insightful decisions and innovate to improve society, their environment, our economies, and change the world with their ideas. That’s what we aim for in #{link_to('our mission', about_page_path)}. Your effort helps everyone.
 
     %h3 What does ‘better access’ mean?
 
@@ -24,8 +25,8 @@
     %p For example, answer only questions marked ‘Pilot’ and you gain yourself a Pilot open data certificate. Next you publish your open data certificate along with your open data and say “<em>look at how much effort we put into publishing this</em>” to people who better understand how to use it.
 
     %p
-      = link_to('See what you will be asked', '/overview', :class => ['btn', 'btn-large'])
-      = link_to('See an example certificate', dataset_latest_certificate_path(example_dataset), :class => ['btn', 'btn-large'])
+      = link_to('See what you will be asked', overview_page_path, :class => ['btn', 'btn-large'])
+      = example_certificate_link
 
     %h3 A seal of approval that helps deliver knowledge for everyone
 

--- a/app/views/surveyor/_status_panel.html.haml
+++ b/app/views/surveyor/_status_panel.html.haml
@@ -4,7 +4,7 @@
     %h2= t('status_panel.title')
     %p
       = t('status_panel.description')
-      =link_to t('status_panel.about'), '/about'
+      =link_to t('status_panel.about'), about_page_path
     %p
       =link_to t('status_panel.improve_data'), surveyor.view_my_survey_requirements_path(:response_set_code => @response_set.access_code)
 

--- a/app/views/surveyor/edit.html.haml
+++ b/app/views/surveyor/edit.html.haml
@@ -69,9 +69,8 @@
             .span8.lead
               != @survey.intro
               %p
-                %a{href: about_url}
+                %a{href: about_page_url}
                   = t('surveys.read_more')
-
 
           .documentation-url
             - question = @survey.documentation_url

--- a/app/views/surveyor/start.html.haml
+++ b/app/views/surveyor/start.html.haml
@@ -41,7 +41,7 @@
           .span8.lead
             != @survey.intro
             %p
-              %a{href: about_url}
+              %a{href: about_page_url}
                 = t('surveys.read_more')
 
         = semantic_form_for [surveyor, :start, @response_set] do |f|

--- a/config/application.rb
+++ b/config/application.rb
@@ -90,12 +90,6 @@ module OpenDataCertificate
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
 
-    # Rails apps no longer can catch ActionController::RoutingError errors, as they're caught earlier in the stack.
-    # This is a workaround from: https://github.com/vidibus/vidibus-routing_error
-    config.after_initialize do |app|
-      app.routes.append{match '*path', :to => 'application#routing_error'}
-    end
-
     config.middleware.insert_before ActionDispatch::ParamsParser, "CatchJsonParseErrors"
 
     config.middleware.insert_before 0, Rack::Cors do

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -433,6 +433,7 @@ zh:
     label:
       user:
         short_name: Short name or preferred way of being addressed
+        preferred_locale: Language
 
   locales:
     en: English

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,15 @@ OpenDataCertificate::Application.routes.draw do
   end
 
   scope '/:locale', constraints: {locale: Regexp.union(I18n.available_locales.map(&:to_s))} do
+    # 'Static' pages managed by HighVoltage here...
     get 'privacy-policy' => 'pages#show', id: 'privacy_policy', as: 'privacy_policy'
+    get 'cookie-policy' => 'pages#show', id: 'cookie_policy', as: 'cookie_policy'
+    get 'terms' => 'pages#show', id: 'terms', as: 'terms_page'
+    get 'about' => 'pages#show', id: 'about', as: 'about_page'
+    get 'overview' => 'pages#show', id: 'overview', as: 'overview_page'
+    get 'contact' => 'pages#show', id: 'contact', as: 'contact_page'
+    get 'markdown' => 'pages#show', id: 'markdown_help', as: 'markdown_help'
+    get 'using-the-marks' => 'pages#show', id: 'branding', as: 'branding_page'
 
     root :to => 'main#home'
   end
@@ -100,15 +108,6 @@ OpenDataCertificate::Application.routes.draw do
 
   # Get badge for a url
   get 'get_badge' => 'certificates#certificate_from_dataset_url'
-
-  # 'Static' pages managed by HighVoltage here...
-  get 'about' => 'pages#show', :id => 'about'
-  get 'overview' => 'pages#show', :id => 'overview'
-  get 'contact' => 'pages#show', :id => 'contact'
-  get 'terms' => 'pages#show', :id => 'terms'
-  get 'cookie-policy' => 'pages#show', :id => 'cookie_policy'
-  get 'markdown' => 'pages#show', :id => 'markdown_help', as: :markdown_help
-  get 'using-the-marks' => 'pages#show', :id => 'branding'
 
   # comment pages
   get 'comment' => 'main#comment', as: :comment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,9 +151,7 @@ OpenDataCertificate::Application.routes.draw do
 
   get 'status/ping' => 'main#ping'
 
-  match '(*path)', to: redirect { |path_params, request|
-    request.fullpath.gsub(%r{/(.*)}, "/#{I18n.default_locale}/\\1")
-  }, constraints: ->(request) {
+  match '(*path)', to: 'locale#redirect_to_locale', constraints: ->(request) {
     !request.params[:path] || !request.params[:path].start_with?(*I18n.available_locales.map(&:to_s))
   }
 end

--- a/db/migrate/20150929145945_add_preferred_locale_to_users.rb
+++ b/db/migrate/20150929145945_add_preferred_locale_to_users.rb
@@ -1,0 +1,5 @@
+class AddPreferredLocaleToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :preferred_locale, :string, default: 'en'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150907141457) do
+ActiveRecord::Schema.define(:version => 20150929145945) do
 
   create_table "answers", :force => true do |t|
     t.integer  "question_id"
@@ -411,6 +411,7 @@ ActiveRecord::Schema.define(:version => 20150907141457) do
     t.string   "unconfirmed_email"
     t.string   "organization"
     t.boolean  "agreed_to_terms"
+    t.string   "preferred_locale",       :default => "en"
   end
 
   add_index "users", ["authentication_token"], :name => "index_users_on_authentication_token", :unique => true

--- a/features/campaigns.feature
+++ b/features/campaigns.feature
@@ -25,7 +25,7 @@ Feature: Display information about campaigns in UI
     And CSV row 0 column "Success?" should be "true"
     And CSV row 0 column "Published?" should be "true"
     And CSV row 0 column "Documentation URL" should be "http://example.com/dataset"
-    And CSV row 0 column "Certificate URL" should be "http://www.example.com/datasets/1/certificates/1"
+    And CSV row 0 column "Certificate URL" should be "http://www.example.com/en/datasets/1/certificates/1"
     And CSV row 0 column "User" should be "api@example.com"
 
   Scenario: See missing questions

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -82,7 +82,7 @@ end
 When(/^I request a certificate via the API$/) do
   authorize @api_user.email, @api_user.authentication_token
 
-  @response = post '/datasets', @body
+  @response = post '/en/datasets', @body
   @status_url = JSON.parse(@response.body)['dataset_url']
 end
 
@@ -96,7 +96,7 @@ When(/^I request the status via the API$/) do
 end
 
 When(/^I request the results via the API$/) do
-  @response = get "/datasets/#{Dataset.last.id}.json"
+  @response = get "/en/datasets/#{Dataset.last.id}.json"
 end
 
 Given(/^that email address is used for an existing user$/) do
@@ -161,7 +161,7 @@ Then(/^there should only be one dataset$/) do
 end
 
 Then(/^I should get the certificate URL$/) do
-  assert_match /\"certificate_url\":\"http:\/\/test\.host\/datasets\/[0-9]+\/certificate.json\"/,  @response.body
+  assert_match /\"certificate_url\":\"http:\/\/test\.host\/en\/datasets\/[0-9]+\/certificate.json\"/,  @response.body
 end
 
 Then(/^my certificate should be linked to a campaign$/) do
@@ -213,7 +213,7 @@ Given(/^I am signed in as the API user$/) do
 end
 
 Given(/^I have signed out$/) do
-  first('a[href="/users/sign_out"]').click
+  first('a[href="/users/sign_out?locale=en"]').click
 end
 
 Then(/^I should be told I need to sign in$/) do

--- a/features/step_definitions/certificate_steps.rb
+++ b/features/step_definitions/certificate_steps.rb
@@ -32,7 +32,7 @@ Given(/^has a published certificate$/) do
 end
 
 When(/I visit the certificate page$/) do
-  visit dataset_certificate_path(@dataset, @certificate)
+  visit dataset_certificate_path('en', @dataset, @certificate)
 end
 
 Then(/I should see the claim button/) do

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class AdminControllerTest < ActionController::TestCase
   include Devise::TestHelpers
@@ -42,7 +42,7 @@ class AdminControllerTest < ActionController::TestCase
 
     assert_response 403
   end
-  
+
   test "user search finds by email fragment" do
     sign_in @admin
     get :typeahead, q: @user.email.split('@').first

--- a/test/functional/application_controller_test.rb
+++ b/test/functional/application_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ApplicationControllerTest < ActionController::TestCase
 

--- a/test/functional/campaigns_controller_test.rb
+++ b/test/functional/campaigns_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class CampaignsControllerTest < ActionController::TestCase
   include Devise::TestHelpers

--- a/test/functional/certificates_controller_test.rb
+++ b/test/functional/certificates_controller_test.rb
@@ -1,11 +1,11 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class CertificatesControllerTest < ActionController::TestCase
   include Devise::TestHelpers
 
   test "published certificates can be shown" do
     cert = FactoryGirl.create(:published_certificate_with_dataset)
-    get :show, {dataset_id: cert.dataset.id, id: cert.id}
+    get :show, {locale: :en, dataset_id: cert.dataset.id, id: cert.id}
     assert_response :success
   end
 
@@ -13,13 +13,13 @@ class CertificatesControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:published_certificate_with_dataset)
     cert.response_set.create_kitten_data
     KittenData.any_instance.stubs(:data).returns(false)
-    get :show, {dataset_id: cert.dataset.id, id: cert.id}
+    get :show, {locale: :en, dataset_id: cert.dataset.id, id: cert.id}
     assert_response :success
   end
 
   test "unpublished certificates can't be shown" do
     cert = FactoryGirl.create(:certificate_with_dataset)
-    get :show, {dataset_id: cert.dataset.id, id: cert.id}
+    get :show, {locale: :en, dataset_id: cert.dataset.id, id: cert.id}
     assert_response 404
   end
 
@@ -30,7 +30,7 @@ class CertificatesControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:certificate_with_dataset)
     cert.response_set.assign_to_user! user
 
-    get :show, {dataset_id: cert.dataset.id, id: cert.id}
+    get :show, {locale: :en, dataset_id: cert.dataset.id, id: cert.id}
 
     assert_response :success
   end
@@ -39,7 +39,7 @@ class CertificatesControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:published_certificate_with_dataset)
     cert.attained_level = "basic"
     cert.save
-    get :show, {dataset_id: cert.dataset.id, id: cert.id, format: "json"}
+    get :show, {locale: :en, dataset_id: cert.dataset.id, id: cert.id, format: "json"}
     assert_response :success
     assert_equal "application/json", response.content_type
   end
@@ -58,7 +58,7 @@ class CertificatesControllerTest < ActionController::TestCase
     cert.save
     get :legacy_show, {id: cert.id, type: "badge", format: "png"}
 
-    assert_redirected_to "http://test.host/datasets/1/certificates/1/badge.png"
+    assert_redirected_to "http://test.host/en/datasets/1/certificates/1/badge.png"
   end
 
   test "Requesting legacy url for embed performs a redirect" do
@@ -67,7 +67,7 @@ class CertificatesControllerTest < ActionController::TestCase
     cert.save
     get :legacy_show, {id: cert.id, type: "embed"}
 
-    assert_redirected_to "http://test.host/datasets/1/certificates/1/embed"
+    assert_redirected_to "http://test.host/en/datasets/1/certificates/1/embed"
   end
 
   test "requesting a legacy url with another type returns a not found" do
@@ -91,7 +91,7 @@ class CertificatesControllerTest < ActionController::TestCase
 
     levels.each do |level, actual|
       cert = FactoryGirl.create(:"published_#{level}_certificate_with_dataset")
-      get :show, {dataset_id: cert.dataset.id, id: cert.id, format: "json"}
+      get :show, {locale: :en, dataset_id: cert.dataset.id, id: cert.id, format: "json"}
 
       json = JSON.parse(response.body)
 
@@ -101,7 +101,7 @@ class CertificatesControllerTest < ActionController::TestCase
 
   test "Requesting a JSON version of a certificate returns the correct juristiction and status" do
     cert = FactoryGirl.create(:published_certificate_with_dataset)
-    get :show, {dataset_id: cert.dataset.id, id: cert.id, format: "json"}
+    get :show, {locale: :en, dataset_id: cert.dataset.id, id: cert.id, format: "json"}
 
     json = JSON.parse(response.body)
 
@@ -111,19 +111,19 @@ class CertificatesControllerTest < ActionController::TestCase
 
   test "Requesting a JSON version of a certificate returns the correct badge urls" do
     cert = FactoryGirl.create(:published_certificate_with_dataset)
-    get :show, {dataset_id: cert.dataset.id, id: cert.id, format: "json"}
+    get :show, {locale: :en, dataset_id: cert.dataset.id, id: cert.id, format: "json"}
 
     json = JSON.parse(response.body)
 
-    assert_equal "http://test.host/datasets/1/certificate/badge.js", json["certificate"]["badges"]["application/javascript"]
-    assert_equal "http://test.host/datasets/1/certificate/badge.html", json["certificate"]["badges"]["text/html"]
-    assert_equal "http://test.host/datasets/1/certificate/badge.png", json["certificate"]["badges"]["image/png"]
+    assert_equal "http://test.host/en/datasets/1/certificate/badge.js", json["certificate"]["badges"]["application/javascript"]
+    assert_equal "http://test.host/en/datasets/1/certificate/badge.html", json["certificate"]["badges"]["text/html"]
+    assert_equal "http://test.host/en/datasets/1/certificate/badge.png", json["certificate"]["badges"]["image/png"]
   end
 
   test "Requesting a JSON version of a certificate in production returns https urls" do
     Rails.env.stubs :production? => true
     cert = FactoryGirl.create(:published_certificate_with_dataset)
-    get :show, {dataset_id: cert.dataset.id, id: cert.id, format: "json"}
+    get :show, {locale: :en, dataset_id: cert.dataset.id, id: cert.id, format: "json"}
 
     json = JSON.parse(response.body)
 
@@ -136,7 +136,7 @@ class CertificatesControllerTest < ActionController::TestCase
 
   test "requesting the png badge image" do
     cert = FactoryGirl.create(:published_certificate_with_dataset)
-    get :badge, {dataset_id: cert.dataset.id, id: cert.id, format: "png"}
+    get :badge, {locale: :en, dataset_id: cert.dataset.id, id: cert.id, format: "png"}
 
     assert_equal File.read(File.join(Rails.root, 'app/assets/images/badges/raw_level_badge.png')), response.body
   end
@@ -147,7 +147,7 @@ class CertificatesControllerTest < ActionController::TestCase
     sign_in user
 
     assert_difference ->{cert.verifications.count}, 1 do
-      post :verify, {dataset_id: cert.dataset.id, id: cert.id}
+      post :verify, {locale: :en, dataset_id: cert.dataset.id, id: cert.id}
     end
   end
 
@@ -156,7 +156,7 @@ class CertificatesControllerTest < ActionController::TestCase
     user = FactoryGirl.create(:user)
 
     assert_no_difference ->{cert.verifications.count} do
-      post :verify, {dataset_id: cert.dataset.id, id: cert.id}
+      post :verify, {locale: :en, dataset_id: cert.dataset.id, id: cert.id}
     end
 
     assert_redirected_to dataset_certificate_url dataset_id: cert.dataset.id, id: cert.id
@@ -169,7 +169,7 @@ class CertificatesControllerTest < ActionController::TestCase
     sign_in cv.user
 
     assert_difference ->{cert.verifications.count}, -1 do
-      post :verify, {dataset_id: cert.dataset.id, id: cert.id, undo: true}
+      post :verify, {locale: :en, dataset_id: cert.dataset.id, id: cert.id, undo: true}
     end
   end
 
@@ -178,7 +178,7 @@ class CertificatesControllerTest < ActionController::TestCase
     user = FactoryGirl.create(:user)
     sign_in user
 
-    put :update, {dataset_id: cert.dataset.id, id: cert.id, audited: true}
+    put :update, {locale: :en, dataset_id: cert.dataset.id, id: cert.id, audited: true}
 
     assert_response 403
   end
@@ -190,7 +190,7 @@ class CertificatesControllerTest < ActionController::TestCase
 
     assert_equal false, cert.audited
 
-    put :update, {dataset_id: cert.dataset.id, id: cert.id, certificate: {audited: true}}
+    put :update, {locale: :en, dataset_id: cert.dataset.id, id: cert.id, certificate: {audited: true}}
 
     cert.reload
     assert_equal true, cert.audited
@@ -203,7 +203,7 @@ class CertificatesControllerTest < ActionController::TestCase
 
     assert_equal true, cert.audited
 
-    put :update, {dataset_id: cert.dataset.id, id: cert.id, certificate: {audited: false}}
+    put :update, {locale: :en, dataset_id: cert.dataset.id, id: cert.id, certificate: {audited: false}}
 
     cert.reload
     assert_equal false, cert.audited
@@ -215,7 +215,7 @@ class CertificatesControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:published_certificate_with_dataset)
 
     assert_difference ->{cert.dataset.embed_stats.count}, 1 do
-      get :badge, {dataset_id: cert.dataset.id, id: cert.id}
+      get :badge, {locale: :en, dataset_id: cert.dataset.id, id: cert.id}
     end
   end
 
@@ -225,7 +225,7 @@ class CertificatesControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:published_certificate_with_dataset)
 
     assert_difference ->{cert.dataset.embed_stats.count}, 1 do
-      get :badge, {dataset_id: cert.dataset.id}
+      get :badge, {locale: :en, dataset_id: cert.dataset.id}
     end
   end
 
@@ -235,10 +235,10 @@ class CertificatesControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:published_certificate_with_dataset)
 
     assert_no_difference ->{cert.dataset.embed_stats.count} do
-      get :badge, {dataset_id: cert.dataset.id, id: cert.id}
+      get :badge, {locale: :en, dataset_id: cert.dataset.id, id: cert.id}
     end
     assert_no_difference ->{cert.dataset.embed_stats.count} do
-      get :badge, {dataset_id: cert.dataset.id}
+      get :badge, {locale: :en, dataset_id: cert.dataset.id}
     end
   end
 
@@ -248,10 +248,10 @@ class CertificatesControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:certificate_with_dataset)
 
     assert_no_difference ->{cert.dataset.embed_stats.count} do
-      get :badge, {dataset_id: cert.dataset.id, id: cert.id}
+      get :badge, {locale: :en, dataset_id: cert.dataset.id, id: cert.id}
     end
     assert_no_difference ->{cert.dataset.embed_stats.count} do
-      get :badge, {dataset_id: cert.dataset.id}
+      get :badge, {locale: :en, dataset_id: cert.dataset.id}
     end
   end
 
@@ -261,10 +261,10 @@ class CertificatesControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:published_certificate_with_dataset)
 
     assert_no_difference ->{cert.dataset.embed_stats.count} do
-      get :badge, {dataset_id: cert.dataset.id, id: cert.id}
+      get :badge, {locale: :en, dataset_id: cert.dataset.id, id: cert.id}
     end
     assert_no_difference ->{cert.dataset.embed_stats.count} do
-      get :badge, {dataset_id: cert.dataset.id}
+      get :badge, {locale: :en, dataset_id: cert.dataset.id}
     end
   end
 
@@ -365,7 +365,7 @@ class CertificatesControllerTest < ActionController::TestCase
 
   test "badge returns not found if certificate is draft" do
     cert = FactoryGirl.create(:certificate_with_dataset)
-    get :badge, {dataset_id: cert.dataset.id}
+    get :badge, {locale: :en, dataset_id: cert.dataset.id}
     assert_response 404
   end
 

--- a/test/functional/certificates_controller_test.rb
+++ b/test/functional/certificates_controller_test.rb
@@ -270,7 +270,7 @@ class CertificatesControllerTest < ActionController::TestCase
 
   test "reporting certificate requires user to be logged in" do
     certificate = FactoryGirl.create(:published_certificate_with_dataset)
-    post :report, dataset_id: certificate.dataset.id, id: certificate.id
+    post :report, locale: 'en', dataset_id: certificate.dataset.id, id: certificate.id
     assert_response :found
   end
 
@@ -278,7 +278,7 @@ class CertificatesControllerTest < ActionController::TestCase
     user = FactoryGirl.create(:user)
     sign_in user
     certificate = FactoryGirl.create(:published_certificate_with_dataset)
-    post :report, dataset_id: certificate.dataset.id, id: certificate.id
+    post :report, locale: 'en', dataset_id: certificate.dataset.id, id: certificate.id
     assert_difference 'ActionMailer::Base.deliveries.size', 1 do
       Delayed::Worker.new.work_off 1
     end
@@ -288,7 +288,7 @@ class CertificatesControllerTest < ActionController::TestCase
     user = FactoryGirl.create(:user)
     sign_in user
     certificate = FactoryGirl.create(:published_certificate_with_dataset)
-    post :report, dataset_id: certificate.dataset.id, id: certificate.id, reasons: "broken"
+    post :report, locale: 'en', dataset_id: certificate.dataset.id, id: certificate.id, reasons: "broken"
     Delayed::Worker.new.work_off 1
     assert_match /broken/, ActionMailer::Base.deliveries.last.body
   end
@@ -298,7 +298,7 @@ class CertificatesControllerTest < ActionController::TestCase
     sign_in user
     certificate = FactoryGirl.create(:published_certificate_with_dataset)
     @request.env['REMOTE_ADDR'] = '255.0.0.1'
-    post :report, dataset_id: certificate.dataset.id, id: certificate.id
+    post :report, locale: 'en', dataset_id: certificate.dataset.id, id: certificate.id
     Delayed::Worker.new.work_off 1
     assert_match /255.0.0.1/, ActionMailer::Base.deliveries.last.body
   end
@@ -308,7 +308,7 @@ class CertificatesControllerTest < ActionController::TestCase
     sign_in user
     certificate = FactoryGirl.create(:published_certificate_with_dataset)
     @request.env['HTTP_USER_AGENT'] = 'Web Browser/1.0'
-    post :report, dataset_id: certificate.dataset.id, id: certificate.id
+    post :report, locale: 'en', dataset_id: certificate.dataset.id, id: certificate.id
     Delayed::Worker.new.work_off 1
     assert_match /Web Browser\/1.0/, ActionMailer::Base.deliveries.last.body
   end
@@ -317,7 +317,7 @@ class CertificatesControllerTest < ActionController::TestCase
     user = FactoryGirl.create(:user)
     sign_in user
     certificate = FactoryGirl.create(:published_certificate_with_dataset)
-    post :report, dataset_id: certificate.dataset.id, id: certificate.id
+    post :report, locale: 'en', dataset_id: certificate.dataset.id, id: certificate.id
     Delayed::Worker.new.work_off 1
     assert ActionMailer::Base.deliveries.last.from.include?(user.email)
   end
@@ -334,7 +334,7 @@ class CertificatesControllerTest < ActionController::TestCase
 
     assert_equal dataset.id, certificate.dataset.id
 
-    get :show, dataset_id: certificate.dataset.id
+    get :show, locale: 'en', dataset_id: certificate.dataset.id
 
     assert_equal certificate, assigns(:certificate)
   end

--- a/test/functional/claims_controller_test.rb
+++ b/test/functional/claims_controller_test.rb
@@ -47,7 +47,7 @@ class ClaimsControllerTest < ActionController::TestCase
     dataset.change_owner!(owner)
 
     post :create, :claim => {:dataset_id => dataset.id}
-    assert_redirected_to new_user_session_path
+    assert_redirected_to new_user_session_path(locale: nil)
   end
 
   test "listing outstanding claims" do

--- a/test/functional/claims_controller_test.rb
+++ b/test/functional/claims_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ClaimsControllerTest < ActionController::TestCase
   include Devise::TestHelpers

--- a/test/functional/claims_mailer_test.rb
+++ b/test/functional/claims_mailer_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ClaimsMailerTest < ActionMailer::TestCase
 

--- a/test/functional/datasets_controller_test.rb
+++ b/test/functional/datasets_controller_test.rb
@@ -12,7 +12,7 @@ class DatasetsControllerTest < ActionController::TestCase
       FactoryGirl.create(:certificate_with_dataset)
     end
 
-    get :index
+    get :index, locale: 'en'
 
     assert_response :success
     assert_equal 5, assigns(:datasets).size
@@ -26,7 +26,7 @@ class DatasetsControllerTest < ActionController::TestCase
 
     cert.response_set.survey.update_attribute(:title, 'UK')
 
-    get :index, jurisdiction: 'UK'
+    get :index, locale: 'en', jurisdiction: 'UK'
 
     assert_response :success
     assert_equal [cert.dataset], assigns(:datasets)
@@ -39,7 +39,7 @@ class DatasetsControllerTest < ActionController::TestCase
 
     cert.update_attribute(:curator, 'theodi')
 
-    get :index, publisher: 'theodi'
+    get :index, locale: 'en', publisher: 'theodi'
 
     assert_response :success
     assert_equal [cert.dataset], assigns(:datasets)
@@ -51,7 +51,7 @@ class DatasetsControllerTest < ActionController::TestCase
     data = FactoryGirl.create(:published_certificate_with_dataset)
     data.dataset.update_attribute(:documentation_url, 'http://data.org/data')
 
-    get :index, :datahub => 'data.org'
+    get :index, locale: 'en', :datahub => 'data.org'
 
     assert_response :success
     assert_equal [data.dataset], assigns(:datasets)
@@ -63,7 +63,7 @@ class DatasetsControllerTest < ActionController::TestCase
     data = FactoryGirl.create(:published_certificate_with_dataset)
     data.dataset.update_attribute(:documentation_url, 'https://data.org/data')
 
-    get :index, :datahub => 'data.org'
+    get :index, locale: 'en', :datahub => 'data.org'
 
     assert_response :success
     assert_equal [data.dataset], assigns(:datasets)
@@ -76,7 +76,7 @@ class DatasetsControllerTest < ActionController::TestCase
       FactoryGirl.create(:published_standard_certificate_with_dataset)
       FactoryGirl.create(:published_exemplar_certificate_with_dataset)
 
-      get :index, :level => level
+      get :index, locale: 'en', :level => level
 
       assert_response :success
       assert_equal 1, assigns(:datasets).size
@@ -88,7 +88,7 @@ class DatasetsControllerTest < ActionController::TestCase
     Timecop.freeze(3.days.ago) { FactoryGirl.create(:published_certificate_with_dataset) }
     FactoryGirl.create(:published_certificate_with_dataset)
 
-    get :index, :since => 2.days.ago.iso8601
+    get :index, locale: 'en', :since => 2.days.ago.iso8601
 
     assert_equal 1, assigns(:datasets).size
   end
@@ -97,25 +97,25 @@ class DatasetsControllerTest < ActionController::TestCase
     Timecop.freeze(3.days.ago) { FactoryGirl.create(:published_certificate_with_dataset) }
     FactoryGirl.create(:published_certificate_with_dataset)
 
-    get :index, :since => "2 days ago"
+    get :index, locale: 'en', :since => "2 days ago"
 
     assert_equal 2, assigns(:datasets).size
   end
 
   test "index (non logged in)" do
-    get :dashboard
+    get :dashboard, locale: 'en'
     assert_response :redirect
   end
 
   test "index no response sets" do
     sign_in FactoryGirl.create(:user)
-    get :dashboard
+    get :dashboard, locale: 'en'
     assert_response 200
   end
 
   test "index response sets" do
     sign_in FactoryGirl.create(:user_with_responses)
-    get :dashboard
+    get :dashboard, locale: 'en'
     assert_response 200
     assert assigns(:datasets).size > 0
   end
@@ -128,7 +128,7 @@ class DatasetsControllerTest < ActionController::TestCase
 
     sign_in user
 
-    get :dashboard
+    get :dashboard, locale: 'en'
     assert_response 200
     assert_equal 1, assigns(:datasets).size
   end
@@ -140,7 +140,7 @@ class DatasetsControllerTest < ActionController::TestCase
     FactoryGirl.create(:published_response_set, dataset: @first)
     FactoryGirl.create(:published_response_set, dataset: @second)
 
-    get :typeahead, mode: 'dataset', q: 'second'
+    get :typeahead, locale: 'en', mode: 'dataset', q: 'second'
     assert_response 200
 
     assert_equal [
@@ -162,7 +162,7 @@ class DatasetsControllerTest < ActionController::TestCase
     @second.curator = 'curator one'
     @second.save
 
-    get :typeahead, mode: 'publisher', q: 'one'
+    get :typeahead, locale: 'en', mode: 'publisher', q: 'one'
     assert_response 200
 
     assert_equal [
@@ -183,7 +183,7 @@ class DatasetsControllerTest < ActionController::TestCase
     # only shows countries with published response sets
     FactoryGirl.create(:response_set, survey: @gb).publish!
 
-    get :typeahead, mode: 'country', q: 'united'
+    get :typeahead, locale: 'en', mode: 'country', q: 'united'
     assert_response 200
 
     assert_equal [
@@ -199,7 +199,7 @@ class DatasetsControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:published_certificate_with_dataset)
     cert.attained_level = "basic"
     cert.save
-    get :show, {id: cert.response_set.dataset.id, format: "feed"}
+    get :show, {locale: 'en', id: cert.response_set.dataset.id, format: "feed"}
     assert_response :success
     assert_equal "application/atom+xml", response.content_type
   end
@@ -208,7 +208,7 @@ class DatasetsControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:published_certificate_with_dataset)
     cert.attained_level = "basic"
     cert.save
-    get :show, {id: cert.response_set.dataset.id, format: "feed"}
+    get :show, {locale: 'en', id: cert.response_set.dataset.id, format: "feed"}
     assert_response :success
 
     feed = RSS::Parser.parse response.body, false
@@ -234,7 +234,7 @@ class DatasetsControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:published_certificate_with_dataset)
     cert.attained_level = "basic"
     cert.save
-    get :show, {id: cert.response_set.dataset.id, format: "feed"}
+    get :show, {locale: 'en', id: cert.response_set.dataset.id, format: "feed"}
     assert_response :success
 
     feed = RSS::Parser.parse response.body, false
@@ -251,7 +251,7 @@ class DatasetsControllerTest < ActionController::TestCase
     10.times do
       cert = FactoryGirl.create(:published_certificate_with_dataset)
     end
-    get :index, { format: "feed" }
+    get :index, { locale: 'en', format: "feed" }
     assert_response :success
 
     assert_equal "application/atom+xml", response.content_type
@@ -260,7 +260,7 @@ class DatasetsControllerTest < ActionController::TestCase
   test "atom feed for all datasets returns the correct stuff" do
     cert = FactoryGirl.create(:published_certificate_with_dataset)
 
-    get :index, { :format => :feed }
+    get :index, { locale: 'en', format: :feed }
 
     feed = RSS::Parser.parse response.body
 
@@ -286,7 +286,7 @@ class DatasetsControllerTest < ActionController::TestCase
 
     cert = FactoryGirl.create(:published_certificate_with_dataset)
 
-    get :index, { :format => :feed }
+    get :index, { locale: 'en', format: :feed }
 
     feed = RSS::Parser.parse response.body
 
@@ -305,7 +305,7 @@ class DatasetsControllerTest < ActionController::TestCase
     recent_time = 2.days.ago.change(:usec => 0).utc
     Timecop.freeze(recent_time) { FactoryGirl.create(:published_certificate_with_dataset) }
 
-    get :index, format: :feed
+    get :index, locale: 'en', format: :feed
 
     last_modified = @response.headers['Last-Modified']
     assert_equal recent_time.httpdate, last_modified
@@ -317,7 +317,7 @@ class DatasetsControllerTest < ActionController::TestCase
     100.times do
       cert = FactoryGirl.create(:published_certificate_with_dataset)
     end
-    get :index, { search: "", format: "json" }
+    get :index, { locale: 'en', search: "", format: "json" }
     assert_response :success
     assert_equal "application/json", response.content_type
   end
@@ -326,7 +326,7 @@ class DatasetsControllerTest < ActionController::TestCase
     100.times do
       cert = FactoryGirl.create(:published_certificate_with_dataset)
     end
-    get :index, { search: "", format: "feed" }
+    get :index, { locale: 'en', search: "", format: "feed" }
     assert_response :success
     assert_equal "application/atom+xml", response.content_type
   end
@@ -335,7 +335,7 @@ class DatasetsControllerTest < ActionController::TestCase
     100.times do
       FactoryGirl.create(:published_certificate_with_dataset)
     end
-    get :index, { search: "Test", format: "feed" }
+    get :index, { locale: 'en', search: "Test", format: "feed" }
     assert_response :success
 
     doc = Nokogiri::XML(response.body)
@@ -346,20 +346,20 @@ class DatasetsControllerTest < ActionController::TestCase
 
   test "requesting a csv sends a redirect to rackspace location" do
     CSVExport.stubs(:download_url).returns("http://rackspace.example.com/open-data-certificates.csv")
-    get :index, format: "csv"
+    get :index, locale: 'en', format: "csv"
     assert_response :redirect
     assert_equal "http://rackspace.example.com/open-data-certificates.csv", response.headers['Location']
   end
 
   test "requesting a csv when it's not generated returns a 404" do
     CSVExport.stubs(:download_url).raises(ActiveRecord::RecordNotFound)
-    get :index, format: "csv"
+    get :index, locale: 'en', format: "csv"
     assert_response :not_found
   end
 
   %w[search since datahub level publisher jurisdiction].each do |term|
     test "requesting a csv with a filter of #{term} returns a 404" do
-      get :index, term => "test", format: "csv"
+      get :index, locale: 'en', term => "test", format: "csv"
 
       assert_response :not_found
     end
@@ -369,7 +369,7 @@ class DatasetsControllerTest < ActionController::TestCase
     FactoryGirl.create(:published_certificate_with_removed_dataset)
     FactoryGirl.create(:published_certificate_with_dataset)
 
-    get :index
+    get :index, locale: 'en'
 
     assert_equal 1, assigns(:datasets).size
 
@@ -377,7 +377,7 @@ class DatasetsControllerTest < ActionController::TestCase
 
   test "creating a certificate without a jurisdiction" do
     http_auth FactoryGirl.create(:user)
-    post :create
+    post :create, locale: 'en'
     body = JSON.parse(response.body)
     assert_equal(422, response.status)
     assert_equal(false, body['success'])
@@ -387,7 +387,7 @@ class DatasetsControllerTest < ActionController::TestCase
   test "creating a certificate requires some dataset information" do
     load_custom_survey 'cert_generator.rb'
     http_auth FactoryGirl.create(:user)
-    post :create, jurisdiction: 'cert-generator'
+    post :create, locale: 'en', jurisdiction: 'cert-generator'
     body = JSON.parse(response.body)
     assert_equal(422, response.status)
     assert_equal(false, body['success'])
@@ -403,7 +403,7 @@ class DatasetsControllerTest < ActionController::TestCase
     CertificateGenerator.any_instance.expects(:generate).once
 
     assert_difference "CertificateGenerator.count", 1 do
-      post :create, locale: :en, jurisdiction: 'cert-generator', dataset: {documentationUrl: dataset.documentation_url}
+      post :create, locale: 'en', locale: :en, jurisdiction: 'cert-generator', dataset: {documentationUrl: dataset.documentation_url}
     end
     body = JSON.parse(response.body)
     assert_equal(202, response.status)
@@ -417,7 +417,7 @@ class DatasetsControllerTest < ActionController::TestCase
     certificate = FactoryGirl.create(:published_certificate_with_dataset)
     dataset = certificate.dataset
     http_auth FactoryGirl.create(:user)
-    post :create, locale: :en, jurisdiction: 'cert-generator', dataset: {documentationUrl: dataset.documentation_url}
+    post :create, locale: 'en', jurisdiction: 'cert-generator', dataset: {documentationUrl: dataset.documentation_url}
     body = JSON.parse(response.body)
     assert_equal(422, response.status)
     assert_equal(false, body['success'])
@@ -433,7 +433,7 @@ class DatasetsControllerTest < ActionController::TestCase
     CertificateGenerator.any_instance.expects(:generate).once
 
     assert_difference "CertificateGenerator.count", 1 do
-      post :create, jurisdiction: 'cert-generator', dataset: {documentationUrl: "http://example.org"}
+      post :create, locale: 'en', jurisdiction: 'cert-generator', dataset: {documentationUrl: "http://example.org"}
     end
     body = JSON.parse(response.body)
     assert_equal(202, response.status)
@@ -450,9 +450,10 @@ class DatasetsControllerTest < ActionController::TestCase
 
     assert_difference "CertificationCampaign.count", 1 do
       post :create, {
-          :campaign => "fourmoreyears",
-          :url => "http://example.org",
-          :jurisdiction => 'cert-generator',
+          locale: 'en',
+          campaign: "fourmoreyears",
+          url: "http://example.org",
+          jurisdiction: 'cert-generator',
           dataset: {documentationUrl: "http://example.org"}
       }
     end
@@ -472,7 +473,7 @@ class DatasetsControllerTest < ActionController::TestCase
     CertificateGeneratorWorker.expects(:perform_async).returns(nil)
 
     assert_difference "CertificationCampaign.count", 1 do
-      post :create, jurisdiction: 'cert-generator',
+      post :create, locale: 'en', jurisdiction: 'cert-generator',
         dataset: {documentationUrl: "http://example.org"},
         campaign: 'fourmoreyears'
     end
@@ -485,7 +486,7 @@ class DatasetsControllerTest < ActionController::TestCase
     user = FactoryGirl.create(:user)
     http_auth user
     generator = CertificateGenerator.create(user: user)
-    get :import_status, certificate_generator_id: generator.id
+    get :import_status, locale: 'en', certificate_generator_id: generator.id
     body = JSON.parse(response.body)
     assert_equal("pending", body['success'])
     assert_equal(status_datasets_url(CertificateGenerator.last), body['dataset_url'])
@@ -497,10 +498,10 @@ class DatasetsControllerTest < ActionController::TestCase
     user = response_set.user
     generator = CertificateGenerator.create(user: user, completed: true, response_set: response_set)
     http_auth user
-    get :import_status, certificate_generator_id: generator.id
+    get :import_status, locale: 'en', certificate_generator_id: generator.id
     assert_redirected_to dataset_url(response_set.dataset_id, format: :json)
     http_auth user
-    get :show, id: response_set.dataset_id, format: :json
+    get :show, locale: 'en', id: response_set.dataset_id, format: :json
     body = JSON.parse(response.body)
     assert_equal(true, body['success'])
     assert_equal(response_set.dataset_id, body['dataset_id'])
@@ -512,7 +513,7 @@ class DatasetsControllerTest < ActionController::TestCase
     user = response_set.user
     generator = CertificateGenerator.create(user: user, completed: true, response_set: response_set)
     http_auth user
-    get :import_status, certificate_generator_id: generator.id
+    get :import_status, locale: 'en', certificate_generator_id: generator.id
     body = JSON.parse(response.body)
     assert_equal(false, body['success'])
     assert_equal(false, body['published'])
@@ -525,12 +526,12 @@ class DatasetsControllerTest < ActionController::TestCase
     other_user = FactoryGirl.create(:user)
     http_auth other_user
     generator = CertificateGenerator.create(user: generating_user)
-    get :import_status, certificate_generator_id: generator.id
+    get :import_status, locale: 'en', certificate_generator_id: generator.id
     assert_response 403
   end
 
   test "dataset info endpoint with no data" do
-    get :info, format: :json
+    get :info, locale: 'en', format: :json
     assert_response :ok
     body = JSON.parse(response.body)
     assert_equal(0, body['published_certificate_count'])
@@ -538,7 +539,7 @@ class DatasetsControllerTest < ActionController::TestCase
 
   test "dataset info with draft certificate" do
     FactoryGirl.create_list(:certificate_with_dataset, 3)
-    get :info, format: :json
+    get :info, locale: 'en', format: :json
     assert_response :ok
     body = JSON.parse(response.body)
     assert_equal(0, body['published_certificate_count'])
@@ -546,7 +547,7 @@ class DatasetsControllerTest < ActionController::TestCase
 
   test "dataset info with published certificates" do
     FactoryGirl.create_list(:published_certificate_with_dataset, 3)
-    get :info, format: :json
+    get :info, locale: 'en', format: :json
     assert_response :ok
     body = JSON.parse(response.body)
     assert_equal(3, body['published_certificate_count'])
@@ -555,7 +556,7 @@ class DatasetsControllerTest < ActionController::TestCase
   test "dataset info with published but expired certificates" do
     certs = FactoryGirl.create_list(:published_certificate_with_dataset, 3)
     certs.last.update_attribute(:expires_at, 1.day.ago)
-    get :info, format: :json
+    get :info, locale: 'en', format: :json
     assert_response :ok
     body = JSON.parse(response.body)
     assert_equal(2, body['published_certificate_count'])
@@ -565,7 +566,7 @@ class DatasetsControllerTest < ActionController::TestCase
     cert = FactoryGirl.create(:published_certificate_with_dataset)
     cert.dataset.update_attribute(:removed, true)
 
-    get :show, id: cert.dataset.id
+    get :show, locale: 'en', id: cert.dataset.id
 
     assert_response :not_found
   end
@@ -576,41 +577,41 @@ class DatasetsControllerTest < ActionController::TestCase
     cert.dataset.update_attribute(:removed, true)
 
     sign_in user
-    get :show, id: cert.dataset.id
+    get :show, locale: 'en', id: cert.dataset.id
 
     assert_response :ok
   end
 
   test "link header is present" do
     FactoryGirl.create_list(:published_certificate_with_dataset, 20*2)
-    get :index
+    get :index, locale: 'en'
     assert response.headers['Link']
   end
 
   test "first link is present in link header" do
     FactoryGirl.create_list(:published_certificate_with_dataset, 20)
-    get :index
+    get :index, locale: 'en'
     links = split_link_header(response.headers['Link'])
     assert_equal datasets_url, links['first']
   end
 
   test "last link is present in link header if more than one page" do
     FactoryGirl.create_list(:published_certificate_with_dataset, 20*3)
-    get :index
+    get :index, locale: 'en'
     links = split_link_header(response.headers['Link'])
     assert_equal datasets_url(page: 3), links['last']
   end
 
   test "last link is not present if only one page of results" do
     FactoryGirl.create_list(:published_certificate_with_dataset, 10)
-    get :index
+    get :index, locale: 'en'
     links = split_link_header(response.headers['Link'])
     assert_nil links['last']
   end
 
   test "adds format to link urls if format not html" do
     FactoryGirl.create_list(:published_certificate_with_dataset, 20*4)
-    get :index, page: 3, format: :json
+    get :index, locale: 'en', page: 3, format: :json
     links = split_link_header(response.headers['Link'])
     assert_equal datasets_url(format: :json), links['first']
     assert_equal datasets_url(format: :json, page: 4), links['last']
@@ -620,7 +621,7 @@ class DatasetsControllerTest < ActionController::TestCase
 
   test "does not use page=1 param for first page" do
     FactoryGirl.create_list(:published_certificate_with_dataset, 20*2)
-    get :index, page: 2, format: :json
+    get :index, locale: 'en', page: 2, format: :json
     links = split_link_header(response.headers['Link'])
     assert_equal datasets_url(format: :json), links['first']
     assert_equal datasets_url(format: :json), links['prev']

--- a/test/functional/datasets_controller_test.rb
+++ b/test/functional/datasets_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 require 'rss'
 
 class DatasetsControllerTest < ActionController::TestCase
@@ -147,7 +147,7 @@ class DatasetsControllerTest < ActionController::TestCase
       {
         "attained_index" => nil,
         "value" =>'my second dataset',
-        "path" => "/datasets/#{@second.id}"
+        "path" => "/en/datasets/#{@second.id}"
       }
     ], assigns(:response)
 
@@ -168,7 +168,7 @@ class DatasetsControllerTest < ActionController::TestCase
     assert_equal [
       {
         "value" =>'curator one',
-        "path" => "/datasets?publisher=curator+one"
+        "path" => "/en/datasets?publisher=curator+one"
       }
     ], assigns(:response)
 
@@ -189,7 +189,7 @@ class DatasetsControllerTest < ActionController::TestCase
     assert_equal [
       {
         "value" =>'United Kingdom',
-        "path" => "/datasets?jurisdiction=GB"
+        "path" => "/en/datasets?jurisdiction=GB"
       }
     ], assigns(:response)
 
@@ -213,17 +213,17 @@ class DatasetsControllerTest < ActionController::TestCase
 
     feed = RSS::Parser.parse response.body, false
 
-    assert_equal "http://test.host/datasets/#{cert.dataset.id}", feed.entry.links[1].href
+    assert_equal "http://test.host/en/datasets/#{cert.dataset.id}", feed.entry.links[1].href
     assert_equal "http://schema.theodi.org/certificate#certificate", feed.entry.links[2].rel
-    assert_equal "http://test.host/datasets/#{cert.dataset.id}/certificate", feed.entry.links[2].href
+    assert_equal "http://test.host/en/datasets/#{cert.dataset.id}/certificate", feed.entry.links[2].href
     assert_equal "http://www.example.com", feed.entry.links[3].href
     assert_equal "about", feed.entry.links[3].rel
-    assert_equal "http://test.host/datasets/#{cert.dataset.id}/certificate.json", feed.entry.links[4].href
+    assert_equal "http://test.host/en/datasets/#{cert.dataset.id}/certificate.json", feed.entry.links[4].href
     assert_equal "alternate", feed.entry.links[4].rel
-    assert_equal "http://test.host/datasets/#{cert.dataset.id}/certificate/badge.html", feed.entry.links[5].href
+    assert_equal "http://test.host/en/datasets/#{cert.dataset.id}/certificate/badge.html", feed.entry.links[5].href
     assert_equal "http://schema.theodi.org/certificate#badge", feed.entry.links[5].rel
     assert_equal "text/html", feed.entry.links[5].type
-    assert_equal "http://test.host/datasets/#{cert.dataset.id}/certificate/badge.js", feed.entry.links[6].href
+    assert_equal "http://test.host/en/datasets/#{cert.dataset.id}/certificate/badge.js", feed.entry.links[6].href
     assert_equal "http://schema.theodi.org/certificate#badge", feed.entry.links[6].rel
     assert_equal "application/javascript", feed.entry.links[6].type
   end
@@ -266,17 +266,17 @@ class DatasetsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal 1, feed.entries.count
-    assert_equal "http://test.host/datasets/#{cert.dataset.id}", feed.entry.links[0].href
+    assert_equal "http://test.host/en/datasets/#{cert.dataset.id}", feed.entry.links[0].href
     assert_equal "http://schema.theodi.org/certificate#certificate", feed.entry.links[1].rel
-    assert_equal "http://test.host/datasets/#{cert.dataset.id}/certificate", feed.entry.links[1].href
+    assert_equal "http://test.host/en/datasets/#{cert.dataset.id}/certificate", feed.entry.links[1].href
     assert_equal "http://www.example.com", feed.entry.links[2].href
     assert_equal "about", feed.entry.links[2].rel
-    assert_equal "http://test.host/datasets/#{cert.dataset.id}/certificate.json", feed.entry.links[3].href
+    assert_equal "http://test.host/en/datasets/#{cert.dataset.id}/certificate.json", feed.entry.links[3].href
     assert_equal "alternate", feed.entry.links[3].rel
-    assert_equal "http://test.host/datasets/#{cert.dataset.id}/certificate/badge.html", feed.entry.links[4].href
+    assert_equal "http://test.host/en/datasets/#{cert.dataset.id}/certificate/badge.html", feed.entry.links[4].href
     assert_equal "http://schema.theodi.org/certificate#badge", feed.entry.links[4].rel
     assert_equal "text/html", feed.entry.links[4].type
-    assert_equal "http://test.host/datasets/#{cert.dataset.id}/certificate/badge.js", feed.entry.links[5].href
+    assert_equal "http://test.host/en/datasets/#{cert.dataset.id}/certificate/badge.js", feed.entry.links[5].href
     assert_equal "http://schema.theodi.org/certificate#badge", feed.entry.links[5].rel
     assert_equal "application/javascript", feed.entry.links[5].type
   end
@@ -403,7 +403,7 @@ class DatasetsControllerTest < ActionController::TestCase
     CertificateGenerator.any_instance.expects(:generate).once
 
     assert_difference "CertificateGenerator.count", 1 do
-      post :create, jurisdiction: 'cert-generator', dataset: {documentationUrl: dataset.documentation_url}
+      post :create, locale: :en, jurisdiction: 'cert-generator', dataset: {documentationUrl: dataset.documentation_url}
     end
     body = JSON.parse(response.body)
     assert_equal(202, response.status)
@@ -417,7 +417,7 @@ class DatasetsControllerTest < ActionController::TestCase
     certificate = FactoryGirl.create(:published_certificate_with_dataset)
     dataset = certificate.dataset
     http_auth FactoryGirl.create(:user)
-    post :create, jurisdiction: 'cert-generator', dataset: {documentationUrl: dataset.documentation_url}
+    post :create, locale: :en, jurisdiction: 'cert-generator', dataset: {documentationUrl: dataset.documentation_url}
     body = JSON.parse(response.body)
     assert_equal(422, response.status)
     assert_equal(false, body['success'])

--- a/test/functional/embed_stats_controller_test.rb
+++ b/test/functional/embed_stats_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class EmbedStatsControllerTest < ActionController::TestCase
   include Devise::TestHelpers
@@ -7,7 +7,7 @@ class EmbedStatsControllerTest < ActionController::TestCase
     dataset = FactoryGirl.create :dataset
     dataset.register_embed("http://example.com")
 
-    get 'index'
+    get 'index', locale: :en
 
     assert_response :success
     assert_equal response.headers["Content-Type"], 'text/csv; header=present; charset=utf-8'

--- a/test/functional/flow_controller_test.rb
+++ b/test/functional/flow_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 require 'flow'
 
 class FlowchartsControllerTest < ActionController::TestCase

--- a/test/functional/jurisdictions_controller_test.rb
+++ b/test/functional/jurisdictions_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class JurisdictionsControllerTest < ActionController::TestCase
   test "should get index" do
@@ -7,7 +7,7 @@ class JurisdictionsControllerTest < ActionController::TestCase
     FactoryGirl.create :survey, title: "GB", access_code: "GB", full_title: "United Kingdom", survey_version: 1
     FactoryGirl.create :survey, title: "AD", access_code: "AD", full_title: "Andorra"
 
-    get :index, use_route: :surveyor
+    get :index, use_route: :surveyor, locale: :en
     assert_response :success
 
     assert_equal 2, assigns(:jurisdictions).size

--- a/test/functional/main_controller_test.rb
+++ b/test/functional/main_controller_test.rb
@@ -4,7 +4,7 @@ class MainControllerTest < ActionController::TestCase
   include Devise::TestHelpers
 
   test "homepage" do
-    get :home
+    get :home, locale: 'en'
     assert_response 200
   end
 
@@ -112,7 +112,7 @@ class MainControllerTest < ActionController::TestCase
 
   test "start_questionnaire with app default jurisdiction" do
 
-    post :start_questionnaire
+    post :start_questionnaire, locale: 'en'
     assert assigns(:response_set).survey == @survey_app_default
 
   end
@@ -120,14 +120,14 @@ class MainControllerTest < ActionController::TestCase
   test "start_questionnaire with user default_jurisdiction set" do
 
     sign_in FactoryGirl.create(:user, default_jurisdiction: 'user_default')
-    post :start_questionnaire
+    post :start_questionnaire, locale: 'en'
     assert assigns(:response_set).survey == @survey_user_default
 
   end
 
   test "start_questionnaire with custom param" do
 
-    post :start_questionnaire, survey_access_code: 'other'
+    post :start_questionnaire, locale: 'en', survey_access_code: 'other'
     assert assigns(:response_set).survey == @survey_other
 
   end
@@ -135,7 +135,7 @@ class MainControllerTest < ActionController::TestCase
   test "start_questionnaire entities belongs to user" do
     sign_in @user = FactoryGirl.create(:user)
 
-    post :start_questionnaire
+    post :start_questionnaire, locale: 'en'
     assert_equal assigns(:response_set).user_id, @user.id, "response set belongs to user"
     assert_equal assigns(:dataset).user_id, @user.id, "dataset belongs to user"
   end

--- a/test/functional/main_controller_test.rb
+++ b/test/functional/main_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class MainControllerTest < ActionController::TestCase
   include Devise::TestHelpers

--- a/test/functional/response_sets_controller_test.rb
+++ b/test/functional/response_sets_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ResponseSetsControllerTest < ActionController::TestCase
   include Devise::TestHelpers
@@ -10,7 +10,7 @@ class ResponseSetsControllerTest < ActionController::TestCase
     sign_in @user
 
     assert_difference('ResponseSet.count', -1) do
-      delete :destroy, use_route: :surveyor, id: @response_set.id
+      delete :destroy, use_route: :surveyor, locale: :en, id: @response_set.id
     end
 
     assert_redirected_to dashboard_path
@@ -25,7 +25,7 @@ class ResponseSetsControllerTest < ActionController::TestCase
     sign_in FactoryGirl.create(:user)
 
     assert_no_difference('ResponseSet.count') do
-      delete :destroy, use_route: :surveyor, id: @response_set.id
+      delete :destroy, use_route: :surveyor, locale: :en, id: @response_set.id
     end
 
     assert_response 302
@@ -39,7 +39,7 @@ class ResponseSetsControllerTest < ActionController::TestCase
 
     sign_in @user
 
-    post :publish, use_route: :surveyor, id: @response_set.id
+    post :publish, use_route: :surveyor, locale: :en, id: @response_set.id
 
     assert_redirected_to dashboard_path
 

--- a/test/functional/surveyor_controller_test.rb
+++ b/test/functional/surveyor_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class SurveyorControllerTest < ActionController::TestCase
   include Devise::TestHelpers
@@ -9,11 +9,12 @@ class SurveyorControllerTest < ActionController::TestCase
 
     assert_no_difference('ResponseSet.count') do
       post :continue, use_route: :surveyor,
+              locale: :en,
               survey_code: @response_set.survey.access_code,
               response_set_code: @response_set.access_code
     end
 
-    assert_redirected_to "/surveys/#{@response_set.survey.access_code}/#{@response_set.access_code}/take"
+    assert_redirected_to "/en/surveys/#{@response_set.survey.access_code}/#{@response_set.access_code}/take"
 
   end
 
@@ -24,12 +25,13 @@ class SurveyorControllerTest < ActionController::TestCase
 
     assert_no_difference('ResponseSet.count') do
       post :continue, use_route: :surveyor,
+              locale: :en,
               survey_code: @response_set.survey.access_code,
               response_set_code: @response_set.access_code,
               update: true
     end
 
-    assert_redirected_to "/surveys/#{@response_set.survey.access_code}/#{@response_set.access_code}/take?update=true"
+    assert_redirected_to "/en/surveys/#{@response_set.survey.access_code}/#{@response_set.access_code}/take?update=true"
 
   end
 
@@ -46,6 +48,7 @@ class SurveyorControllerTest < ActionController::TestCase
 
     assert_difference('ResponseSet.count', 1) do
       post :continue, use_route: :surveyor,
+              locale: :en,
               survey_code: @response_set.survey.access_code,
               response_set_code: @response_set.access_code
     end
@@ -53,7 +56,7 @@ class SurveyorControllerTest < ActionController::TestCase
     # redirected to the new survey
     r = ResponseSet.last
     assert_not_equal @response_set, r
-    assert_redirected_to "/surveys/#{r.survey.access_code}/#{r.access_code}/take"
+    assert_redirected_to "/en/surveys/#{r.survey.access_code}/#{r.access_code}/take"
 
   end
 
@@ -65,12 +68,13 @@ class SurveyorControllerTest < ActionController::TestCase
 
     assert_difference 'ResponseSet.count', 1 do
       post :continue, use_route: :surveyor,
+              locale: :en,
               survey_code: @response_set.survey.access_code,
               response_set_code: @response_set.access_code
     end
 
     r = ResponseSet.last
-    assert_redirected_to "/surveys/#{r.survey.access_code}/#{r.access_code}/take"
+    assert_redirected_to "/en/surveys/#{r.survey.access_code}/#{r.access_code}/take"
   end
 
   test "updating a response_set is published if it was from an update to an already published response set" do
@@ -79,6 +83,7 @@ class SurveyorControllerTest < ActionController::TestCase
     sign_in @response_set.user
 
     post :update, use_route: :surveyor,
+                  locale: :en,
                   survey_code: @response_set.survey.access_code,
                   response_set_code: @response_set.access_code,
                   update: true # this indicates it was previously published
@@ -98,13 +103,14 @@ class SurveyorControllerTest < ActionController::TestCase
 
     assert_difference 'ResponseSet.count', 1 do
       post :continue, use_route: :surveyor,
+              locale: :en,
               survey_code: @response_set.survey.access_code,
               response_set_code: @response_set.access_code
     end
 
     r = ResponseSet.last
     assert_equal r.survey.access_code, 'gb'
-    assert_redirected_to "/surveys/#{r.survey.access_code}/#{r.access_code}/take"
+    assert_redirected_to "/en/surveys/#{r.survey.access_code}/#{r.access_code}/take"
 
   end
 
@@ -114,12 +120,13 @@ class SurveyorControllerTest < ActionController::TestCase
 
     assert_no_difference('ResponseSet.count') do
       post :continue, use_route: :surveyor,
+              locale: :en,
               survey_code: @response_set.survey.access_code,
               response_set_code: @response_set.access_code,
               question: 123
     end
 
-    assert_redirected_to "/surveys/#{@response_set.survey.access_code}/#{@response_set.access_code}/take#q_123"
+    assert_redirected_to "/en/surveys/#{@response_set.survey.access_code}/#{@response_set.access_code}/take#q_123"
   end
 
   test "continue a completed questionnaire with highlighted question" do
@@ -130,13 +137,14 @@ class SurveyorControllerTest < ActionController::TestCase
 
     assert_difference 'ResponseSet.count', 1 do
       post :continue, use_route: :surveyor,
+              locale: :en,
               survey_code: @response_set.survey.access_code,
               response_set_code: @response_set.access_code,
               question: 123
     end
 
     r = ResponseSet.last
-    assert_redirected_to "/surveys/#{r.survey.access_code}/#{r.access_code}/take#q_123"
+    assert_redirected_to "/en/surveys/#{r.survey.access_code}/#{r.access_code}/take#q_123"
   end
 
   test "start page" do
@@ -146,11 +154,12 @@ class SurveyorControllerTest < ActionController::TestCase
     section = FactoryGirl.create(:survey_section)
     survey.sections << section
     question = FactoryGirl.create(:question, reference_identifier: "documentationUrl", survey_section: section)
-    question.answers << FactoryGirl.create(:answer) 
+    question.answers << FactoryGirl.create(:answer)
 
     sign_in @response_set.user
 
     get :start, use_route: :surveyor,
+            locale: :en,
             survey_code: @response_set.survey.access_code,
             response_set_code: @response_set.access_code
 
@@ -161,6 +170,7 @@ class SurveyorControllerTest < ActionController::TestCase
     FactoryGirl.create(:survey, access_code: 'gb')
 
     get :edit, use_route: :surveyor,
+      locale: :en,
       survey_code: "gb",
       response_set: "nope"
 
@@ -175,6 +185,7 @@ class SurveyorControllerTest < ActionController::TestCase
     sign_in response_set.user
 
     get :repeater_field, use_route: :surveyor,
+      locale: :en,
       survey_code: 'gb',
       response_set_code: response_set.access_code,
       question_id: question.id,

--- a/test/functional/transfer_mailer_test.rb
+++ b/test/functional/transfer_mailer_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class TransferMailerTest < ActionMailer::TestCase
 

--- a/test/functional/transfers_controller_test.rb
+++ b/test/functional/transfers_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class TransfersControllerTest < ActionController::TestCase
   include Devise::TestHelpers
@@ -14,7 +14,7 @@ class TransfersControllerTest < ActionController::TestCase
       post :create, transfer: transfer.attributes
     end
 
-    assert_redirected_to '/users/dashboard'
+    assert_redirected_to '/users/dashboard?locale=en'
 
     assert_equal 'Transfer created', flash[:notice]
     assert_equal user, assigns(:transfer).user
@@ -40,7 +40,7 @@ class TransfersControllerTest < ActionController::TestCase
 
     get :claim, id: transfer.id
     assert_response :success
-    assert_equal "/transfers/#{transfer.id}/claim", session[:user_return_to]
+    assert_equal "/transfers/#{transfer.id}/claim?locale=en", session[:user_return_to]
   end
 
   test "accept claim" do
@@ -51,7 +51,7 @@ class TransfersControllerTest < ActionController::TestCase
       put :accept, id: transfer.id, transfer: {token_confirmation: transfer.token}
     end
 
-    assert_redirected_to '/users/dashboard'
+    assert_redirected_to '/users/dashboard?locale=en'
     assert_equal I18n.t('transfers.flashes.complete'), flash[:notice]
     assert transfer.reload.accepted?
 

--- a/test/integration/api_authentication_test.rb
+++ b/test/integration/api_authentication_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 require "base64"
 
 class ApiAuthenticationTest < ActionDispatch::IntegrationTest
@@ -9,13 +9,13 @@ class ApiAuthenticationTest < ActionDispatch::IntegrationTest
 
   test "Unauthorised user tries to create a dataset" do
     cert = FactoryGirl.create(:published_certificate_with_dataset)
-    post "/datasets", {}, {"HTTP_AUTHORIZATION" => "Basic "+Base64.encode64('test@example.com:test123').gsub(/\n/, '')}
+    post "/en/datasets", {}, {"HTTP_AUTHORIZATION" => "Basic "+Base64.encode64('test@example.com:test123').gsub(/\n/, '')}
     assert_response :unauthorized
   end
 
   test "Authorised user tries to create a dataset" do
     cert = FactoryGirl.create(:published_certificate_with_dataset)
-    post "/datasets", {}, {"HTTP_AUTHORIZATION" => "Basic "+Base64.encode64('test@example.com:test1234').gsub(/\n/, '')}
+    post "/en/datasets", {}, {"HTTP_AUTHORIZATION" => "Basic "+Base64.encode64('test@example.com:test1234').gsub(/\n/, '')}
     assert_response :unprocessable_entity
   end
 end

--- a/test/integration/data_dump_test.rb
+++ b/test/integration/data_dump_test.rb
@@ -1,9 +1,9 @@
-# require 'test_helper'
+# require_relative '../test_helper'
 # require File.join(Rails.root, 'lib/extra/certificate_dump')
 # require File.join(Rails.root, 'lib/extra/stats_dump')
-# 
+#
 # class DataDumpTest < ActionDispatch::IntegrationTest
-#   
+#
 #   def service
 #     Fog::Storage.new({
 #       :provider            => 'Rackspace',
@@ -13,66 +13,66 @@
 #       :rackspace_region    => :lon
 #     })
 #   end
-#   
+#
 #   def dir
 #     service.directories.get ENV['RACKSPACE_CERTIFICATE_DUMP_CONTAINER']
 #   end
-#   
+#
 #   def teardown
 #     dir.files.all.each { |file| file.destroy }
 #   end
-# 
-#   test "JSON dump gets dumped with the correct data to Rackspace" do        
+#
+#   test "JSON dump gets dumped with the correct data to Rackspace" do
 #     10.times do
 #       FactoryGirl.create(:published_certificate_with_dataset)
 #     end
-#     
+#
 #     CertificateDump.current
 #     file = dir.files.get "certificates.json"
 #     json = JSON.parse(file.body)
-#     
+#
 #     assert_not_nil file
 #     assert_equal "application/json", file.content_type
 #     assert_equal 10, json["certificates"].length
 #   end
-#   
-#   test "JSON dump gets updated with updated data when the update task is run" do    
+#
+#   test "JSON dump gets updated with updated data when the update task is run" do
 #     10.times do
 #       FactoryGirl.create(:published_certificate_with_dataset)
 #     end
-#     
+#
 #     CertificateDump.current
-#     
+#
 #     updated = Certificate.where(:published => true).first
 #     updated.attained_level = "standard"
 #     updated.save
-#     
+#
 #     new = FactoryGirl.create(:published_certificate_with_dataset)
-#     
+#
 #     CertificateDump.latest
-#         
+#
 #     file = dir.files.get "certificates.json"
 #     json = JSON.parse(file.body)
-#         
+#
 #     assert_equal 11, json["certificates"].length
 #     assert_equal "Standard", json["certificates"][dataset_certificate_url(updated.dataset, updated)]["level"]
 #   end
-#   
+#
 #   test "Certificate delayed job runs the current task when a file does not exist" do
 #     CertificateDump.expects(:current).once
 #     CertificateDump.perform
 #   end
-#   
-#   test "Certificate delayed job runs the latest task when a file exists" do  
+#
+#   test "Certificate delayed job runs the latest task when a file exists" do
 #     10.times do
 #       FactoryGirl.create(:published_certificate_with_dataset)
 #     end
 #     CertificateDump.current
-#     
+#
 #     CertificateDump.expects(:latest).once
 #     CertificateDump.perform
 #   end
-#   
+#
 #   test "Statistics dump gets dumped with the correct data to Rackspace" do
 #     levels = {
 #       :basic    => 7,
@@ -80,28 +80,28 @@
 #       :standard => 5,
 #       :expert   => 4
 #       }
-#     
+#
 #     levels[:basic].times do
 #       FactoryGirl.create(:published_certificate_with_dataset)
 #     end
-#     
+#
 #     levels[:pilot].times do
 #       FactoryGirl.create(:published_pilot_certificate_with_dataset)
 #     end
-#   
+#
 #     levels[:standard].times do
 #       FactoryGirl.create(:published_standard_certificate_with_dataset)
 #     end
-#   
+#
 #     levels[:expert].times do
 #       FactoryGirl.create(:published_expert_certificate_with_dataset)
 #     end
-#     
+#
 #     StatsDump.setup
-#   
+#
 #     file = dir.files.get "statistics.csv"
 #     csv = CSV.parse(file.body)
-#         
+#
 #     assert_not_nil file
 #     assert_equal "text/csv", file.content_type
 #     assert_equal levels.values.sum.to_s, csv[1][3]
@@ -110,40 +110,40 @@
 #     assert_equal levels[:standard].to_s, csv[1][8]
 #     assert_equal levels[:expert].to_s, csv[1][9]
 #   end
-#   
+#
 #   test "Statistics dump appends data to statistics CSV" do
 #     10.times do
 #       FactoryGirl.create(:published_certificate_with_dataset)
 #     end
-#     
+#
 #     StatsDump.setup
-#     
+#
 #     10.times do
 #       FactoryGirl.create(:published_certificate_with_dataset)
 #     end
-#     
+#
 #     StatsDump.latest
-#     
+#
 #     file = dir.files.get "statistics.csv"
 #     csv = CSV.parse(file.body)
-#       
+#
 #     assert_not_nil file
 #     assert_equal 3, csv.count
 #   end
-#   
+#
 #   test "Statistics delayed job runs the setup task when a file does not exist" do
 #     StatsDump.expects(:setup).once
 #     StatsDump.perform
 #   end
-#   
-#   test "Statistics delayed job runs the latest task when a file exists" do  
+#
+#   test "Statistics delayed job runs the latest task when a file exists" do
 #     10.times do
 #       FactoryGirl.create(:published_certificate_with_dataset)
 #     end
 #     StatsDump.setup
-#     
+#
 #     StatsDump.expects(:latest).once
 #     StatsDump.perform
 #   end
-# 
+#
 # end

--- a/test/integration/locale_routing_test.rb
+++ b/test/integration/locale_routing_test.rb
@@ -1,0 +1,27 @@
+require_relative '../test_helper'
+
+class LocaleRoutingTest < ActionDispatch::IntegrationTest
+
+  test "route with a locale succedes" do
+    get '/en/privacy-policy'
+    assert_response :success
+  end
+
+  test "route with a non-default locale succedes" do
+    get '/cs/privacy-policy'
+    assert_response :success
+  end
+
+  test "route missing locale gets redirected to default locale" do
+    get '/privacy-policy'
+    assert_response 301
+    assert_redirected_to '/en/privacy-policy'
+  end
+
+  test "route with a locale to a missing page responds with a routing error" do
+    assert_raises(ActionController::RoutingError) {
+      get '/en/does_not_exist'
+    }
+  end
+
+end

--- a/test/integration/locale_routing_test.rb
+++ b/test/integration/locale_routing_test.rb
@@ -14,7 +14,6 @@ class LocaleRoutingTest < ActionDispatch::IntegrationTest
 
   test "route missing locale gets redirected to default locale" do
     get '/privacy-policy'
-    assert_response 301
     assert_redirected_to '/en/privacy-policy'
   end
 
@@ -22,6 +21,18 @@ class LocaleRoutingTest < ActionDispatch::IntegrationTest
     assert_raises(ActionController::RoutingError) {
       get '/en/does_not_exist'
     }
+  end
+
+  context "with a signed-in user" do
+    setup do
+      user = FactoryGirl.create(:user, preferred_locale: 'cs')
+      post_via_redirect '/users/sign_in', "user[email]" => user.email, "user[password]" => 'testpassword'
+    end
+
+    should "redirect to the user's preferred locale" do
+      get '/privacy-policy'
+      assert_redirected_to '/cs/privacy-policy'
+    end
   end
 
 end

--- a/test/integration/redirects_test.rb
+++ b/test/integration/redirects_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class RedirectsTest < ActionDispatch::IntegrationTest
 
@@ -7,71 +7,71 @@ class RedirectsTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to '/users/dashboard'
   end
-  
+
   test "certificate URL redirects" do
     cert = FactoryGirl.create(:published_certificate_with_dataset)
     get "/certificates/#{cert.id}"
     assert_response :redirect
-    assert_redirected_to "/datasets/#{cert.response_set.dataset.id}/certificates/#{cert.id}"
+    assert_redirected_to "/en/datasets/#{cert.response_set.dataset.id}/certificates/#{cert.id}"
   end
-  
+
   test "certificate embed URL redirects" do
     cert = FactoryGirl.create(:published_certificate_with_dataset)
     get "/certificates/#{cert.id}/embed"
     assert_response :redirect
-    assert_redirected_to "/datasets/#{cert.response_set.dataset.id}/certificates/#{cert.id}/embed"
+    assert_redirected_to "/en/datasets/#{cert.response_set.dataset.id}/certificates/#{cert.id}/embed"
   end
 
   test "certificate badge URL redirects" do
     cert = FactoryGirl.create(:published_certificate_with_dataset)
     get "/certificates/#{cert.id}/badge"
     assert_response :redirect
-    assert_redirected_to "/datasets/#{cert.response_set.dataset.id}/certificates/#{cert.id}/badge"
+    assert_redirected_to "/en/datasets/#{cert.response_set.dataset.id}/certificates/#{cert.id}/badge"
   end
-  
+
   test "user edit URL redirects" do
     user = FactoryGirl.create(:user)
     post_via_redirect '/users/sign_in', "user[email]" => user.email, "user[password]" => 'testpassword'
     assert_response :success
     get "/users/edit"
     assert_response :redirect
-    assert_redirected_to "/users/#{user.id}/edit"
+    assert_redirected_to "/users/#{user.id}/edit?locale=en"
   end
-  
+
   context "certificate from dataset URL" do
-    
+
     setup do
       @cert = FactoryGirl.create(:published_certificate_with_dataset)
     end
-    
+
     should "redirect to the certificate page if no type is specified" do
-       get "/datasets?datasetUrl=http://www.example.com"
+       get "/en/datasets?datasetUrl=http://www.example.com"
        assert_response :redirect
-       assert_redirected_to "/datasets/#{@cert.response_set.dataset.id}/certificates/#{@cert.id}"
+       assert_redirected_to "/en/datasets/#{@cert.response_set.dataset.id}/certificates/#{@cert.id}"
     end
-    
+
     should "redirect to the embed page if embed type is specified" do
-      get "/datasets/embed?datasetUrl=http://www.example.com"
+      get "/en/datasets/embed?datasetUrl=http://www.example.com"
       assert_response :redirect
-      assert_redirected_to "/datasets/#{@cert.response_set.dataset.id}/certificates/#{@cert.id}/embed"
+      assert_redirected_to "/en/datasets/#{@cert.response_set.dataset.id}/certificates/#{@cert.id}/embed"
     end
 
     should "redirect to the badge if badge type is specified" do
-      get "/datasets/badge?datasetUrl=http://www.example.com"
+      get "/en/datasets/badge?datasetUrl=http://www.example.com"
       assert_response :redirect
-      assert_redirected_to "/datasets/#{@cert.response_set.dataset.id}/certificates/#{@cert.id}/badge"
+      assert_redirected_to "/en/datasets/#{@cert.response_set.dataset.id}/certificates/#{@cert.id}/badge"
     end
-    
+
     should "preserve the format if a format is specified" do
-      get "/datasets.json?datasetUrl=http://www.example.com"
+      get "/en/datasets.json?datasetUrl=http://www.example.com"
       assert_response :redirect
-      assert_redirected_to "/datasets/#{@cert.response_set.dataset.id}/certificates/#{@cert.id}.json"
-      
-      get "/datasets/badge.js?datasetUrl=http://www.example.com"
+      assert_redirected_to "/en/datasets/#{@cert.response_set.dataset.id}/certificates/#{@cert.id}.json"
+
+      get "/en/datasets/badge.js?datasetUrl=http://www.example.com"
       assert_response :redirect
-      assert_redirected_to "/datasets/#{@cert.response_set.dataset.id}/certificates/#{@cert.id}/badge.js"
+      assert_redirected_to "/en/datasets/#{@cert.response_set.dataset.id}/certificates/#{@cert.id}/badge.js"
     end
-    
+
   end
 
 end

--- a/test/integration/user_management_test.rb
+++ b/test/integration/user_management_test.rb
@@ -1,0 +1,15 @@
+require_relative '../test_helper'
+
+class UserManagementTest < ActionDispatch::IntegrationTest
+
+  setup do
+    user = FactoryGirl.create(:user, preferred_locale: 'cs')
+    post_via_redirect '/users/sign_in', "user[email]" => user.email, "user[password]" => 'testpassword'
+  end
+
+  test "user is redirected to their preferred locale after update" do
+    post '/users', preferred_locale: 'en'
+    assert_redirected_to dashboard_path(locale: 'en')
+  end
+
+end

--- a/test/performance/browsing_test.rb
+++ b/test/performance/browsing_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 require 'rails/performance_test_help'
 
 class BrowsingTest < ActionDispatch::PerformanceTest

--- a/test/unit/autocomplete_override_message_test.rb
+++ b/test/unit/autocomplete_override_message_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class AutocompleteOverrideMessageTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/unit/certificate_generator_test.rb
+++ b/test/unit/certificate_generator_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class CertificateGeneratorTest < ActiveSupport::TestCase
 

--- a/test/unit/certificate_test.rb
+++ b/test/unit/certificate_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class CertificateTest < ActiveSupport::TestCase
 
@@ -143,7 +143,7 @@ class CertificateTest < ActiveSupport::TestCase
   test 'returns url of certificate' do
     certificate = FactoryGirl.create(:response_set_with_dataset).certificate
 
-    assert_match /http:\/\/test\.host\/datasets\/[0-9]+\/certificates\/[0-9]+/, certificate.url
+    assert_match %r{http://test\.host/en/datasets/[0-9]+/certificates/[0-9]+}, certificate.url
   end
 end
 

--- a/test/unit/claim_test.rb
+++ b/test/unit/claim_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ClaimTest < ActiveSupport::TestCase
   def setup

--- a/test/unit/csv_export_test.rb
+++ b/test/unit/csv_export_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class CSVExportTest < ActiveSupport::TestCase
 
@@ -37,7 +37,7 @@ class CSVExportTest < ActiveSupport::TestCase
     file = mock()
     files.expects(:head).with(CSVExport::FILENAME).returns(file)
     file.expects(:public_url).returns("http://rackspace.example.com/file.csv")
-    
+
     assert_equal "http://rackspace.example.com/file.csv", CSVExport.download_url
   end
 

--- a/test/unit/dataset_test.rb
+++ b/test/unit/dataset_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class DatasetTest < ActiveSupport::TestCase
 
@@ -241,7 +241,7 @@ class DatasetTest < ActiveSupport::TestCase
   test 'returns an api_url' do
     dataset = FactoryGirl.create(:dataset)
 
-    assert_equal "http://test.host/datasets/1.json", dataset.api_url
+    assert_equal "http://test.host/en/datasets/1.json", dataset.api_url
   end
 
 end

--- a/test/unit/dev_event_test.rb
+++ b/test/unit/dev_event_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class DevEventTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/unit/embed_stat_test.rb
+++ b/test/unit/embed_stat_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class EmbedStatTest < ActiveSupport::TestCase
 
@@ -55,12 +55,12 @@ class EmbedStatTest < ActiveSupport::TestCase
     assert_equal csv.first, ["Dataset Name", "Dataset URL", "Referring URL", "First Detected"]
 
     assert_equal csv[1][0], "Dataset 0"
-    assert_equal csv[1][1], "http://test.host/datasets/1"
+    assert_equal csv[1][1], "http://test.host/en/datasets/1"
     assert_equal csv[1][2], "http://example0.com/0"
     assert_equal Date.parse(csv[1][3]), Date.today
 
     assert_equal csv.last[0], "Dataset 4"
-    assert_equal csv.last[1], "http://test.host/datasets/5"
+    assert_equal csv.last[1], "http://test.host/en/datasets/5"
     assert_equal csv.last[2], "http://example4.com/1"
     assert_equal Date.parse(csv.last[3]), Date.today
   end

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 require 'flow'
 
 class FlowTest < ActiveSupport::TestCase

--- a/test/unit/generate_stats_test.rb
+++ b/test/unit/generate_stats_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class GenerateStatsTest < ActiveSupport::TestCase
 

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'test_helper'
+require_relative '../../test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
   test 'scopes the locale' do
@@ -105,6 +105,8 @@ class ApplicationHelperTest < ActionView::TestCase
     FactoryGirl.create_list(:published_basic_certificate_with_dataset, 3)
     pilot = FactoryGirl.create(:published_pilot_certificate_with_dataset)
 
-    assert_equal pilot.dataset, example_dataset
+    expected_link = link_to('See an example certificate', dataset_latest_certificate_path(:en, pilot.dataset), :class => ['btn', 'btn-large'])
+
+    assert_equal expected_link, example_certificate_link
   end
 end

--- a/test/unit/helpers/campaigns_helper_test.rb
+++ b/test/unit/helpers/campaigns_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class CampaignsHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/datasets_helper_test.rb
+++ b/test/unit/helpers/datasets_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class DatasetHelperTest < ActionView::TestCase
-end

--- a/test/unit/kitten_data_test.rb
+++ b/test/unit/kitten_data_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 require 'mocha/setup'
 
 class KittenDataTest < ActiveSupport::TestCase
@@ -33,15 +33,15 @@ class KittenDataTest < ActiveSupport::TestCase
     )
 
     rights = DataKitten::Rights.new(
-      uri: 'http://example.com/rights', 
-      dataLicense: "http://opendatacommons.org/licenses/pddl/", 
+      uri: 'http://example.com/rights',
+      dataLicense: "http://opendatacommons.org/licenses/pddl/",
       contentLicense: "http://creativecommons.org/licenses/by/2.0/uk/"
     )
 
     license = DataKitten::License.new(uri: "http://opendatacommons.org/licenses/by/")
 
     temporal = DataKitten::Temporal.new(start: Date.new, end: Date.new)
-    
+
     spatial = {
       "type" => "Polygon",
       "coordinates" => [[
@@ -226,11 +226,11 @@ class KittenDataTest < ActiveSupport::TestCase
   end
 
   test 'Release type is detected as a collection (from metadata)' do
-    source = { 
+    source = {
       "extras" => { "collection_metadata" => "true" }
     }
     DataKitten::Dataset.any_instance.stubs(:source).returns(source)
-  
+
     assert_equal 'collection', kitten_data.fields["releaseType"]
   end
 
@@ -251,16 +251,16 @@ class KittenDataTest < ActiveSupport::TestCase
   end
 
   test 'Release type is detected as a service when one of the distributions is an API' do
-    source = { 
+    source = {
       "resources" => [{ "resource_type" => "api" }]
     }
     DataKitten::Dataset.any_instance.stubs(:source).returns(source)
-  
+
     assert_equal 'service', kitten_data.fields["releaseType"]
   end
 
   test 'Release type is detected from provided field' do
-    source = { 
+    source = {
       "extras" => { "resource-type" => "service" }
     }
     DataKitten::Dataset.any_instance.stubs(:source).returns(source)
@@ -270,12 +270,12 @@ class KittenDataTest < ActiveSupport::TestCase
   test 'Service type is detected as changing when update frequency is specified' do
     DataKitten::Dataset.any_instance.stubs(:update_frequency).returns('daily')
     DataKitten::Dataset.any_instance.stubs(:description).returns('This is an API')
-    
+
     assert_equal "changing", kitten_data.fields["serviceType"]
   end
 
   test 'Data type is detected as geographic from metadata' do
-    source = { 
+    source = {
       "extras" => { "metadata_type" => "geospatial" }
     }
     DataKitten::Dataset.any_instance.stubs(:source).returns(source)
@@ -285,25 +285,25 @@ class KittenDataTest < ActiveSupport::TestCase
 
   test 'Frequently changing data detected when update frequency is at least daily' do
     DataKitten::Dataset.any_instance.stubs(:update_frequency).returns('daily')
-    
+
     assert_equal "true", kitten_data.fields["frequentChanges"]
   end
 
   test 'Data does not frequently change when update frequency is less often than daily' do
     DataKitten::Dataset.any_instance.stubs(:update_frequency).returns('monthly')
-    
+
     assert_equal "false", kitten_data.fields["frequentChanges"]
   end
 
   test 'Technical documentation is detected when there is a documentation resource' do
     source = {
-      "resources" => [{ 
+      "resources" => [{
         "url" => "http://example.org/docs",
         "resource_type" => "documentation"
       }]
     }
     DataKitten::Dataset.any_instance.stubs(:source).returns(source)
-    
+
     assert_equal "http://example.org/docs", kitten_data.fields["technicalDocumentation"]
   end
 
@@ -336,13 +336,13 @@ class KittenDataTest < ActiveSupport::TestCase
     assert_equal "ogl_uk", kitten_data.fields["dataLicence"]
     assert_equal "ogl_uk", kitten_data.fields["contentLicence"]
   end
-  
+
   test 'If the data license covers content, set it also as a content license' do
     license = DataKitten::License.new({})
     license.abbr = "cc-zero"
     DataKitten::Dataset.any_instance.stubs(:licenses).returns([license])
     DataKitten::Dataset.any_instance.stubs(:rights).returns(nil)
-    
+
     assert_equal "yes", kitten_data.fields["publisherRights"]
     assert_equal "cc_zero", kitten_data.fields["dataLicence"]
     assert_equal "cc_zero", kitten_data.fields["contentLicence"]
@@ -353,7 +353,7 @@ class KittenDataTest < ActiveSupport::TestCase
     license.abbr = "odc-pddl"
     DataKitten::Dataset.any_instance.stubs(:licenses).returns([license])
     DataKitten::Dataset.any_instance.stubs(:rights).returns(nil)
-    
+
     assert_equal "yes", kitten_data.fields["publisherRights"]
     assert_equal "odc_pddl", kitten_data.fields["dataLicence"]
     assert_nil kitten_data.fields["contentLicence"]
@@ -504,7 +504,7 @@ class KittenDataTest < ActiveSupport::TestCase
       "spatial",
       "language"
     ]
-    
+
     assert_equal metadata, kitten_data.fields["documentationMetadata"]
   end
 
@@ -525,7 +525,7 @@ class KittenDataTest < ActiveSupport::TestCase
       "byteSize",
       "mediaType"
     ]
-    
+
     assert_equal metadata, kitten_data.fields["distributionMetadata"]
   end
 
@@ -560,7 +560,7 @@ class KittenDataTest < ActiveSupport::TestCase
       "codelist" => [{ "url" => "http://example.org/codelist", "name" => "codelist" }]
     }
     DataKitten::Dataset.any_instance.stubs(:source).returns(source)
-    
+
     assert_equal "true", kitten_data.fields["codelists"]
     assert_equal "http://example.org/codelist", kitten_data.fields["codelistDocumentationUrl"]
   end
@@ -570,7 +570,7 @@ class KittenDataTest < ActiveSupport::TestCase
       "schema" => [{ "url" => "http://example.org/schema.json", "name" => "schema" }]
     }
     DataKitten::Dataset.any_instance.stubs(:source).returns(source)
-    
+
     assert_equal "true", kitten_data.fields["vocabulary"]
   end
 
@@ -579,7 +579,7 @@ class KittenDataTest < ActiveSupport::TestCase
       "resources" => [{ "schema-url" => "http://example.org/schema.json" }]
     }
     DataKitten::Dataset.any_instance.stubs(:source).returns(source)
-    
+
     assert_equal "true", kitten_data.fields["vocabulary"]
   end
 

--- a/test/unit/lib/translations_test.rb
+++ b/test/unit/lib/translations_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../../test_helper'
 
 require 'translations'
 

--- a/test/unit/odc_rake_test.rb
+++ b/test/unit/odc_rake_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 require 'rake'
 OpenDataCertificate::Application.load_tasks
 
@@ -84,7 +84,7 @@ class OdcRakeTest < ActiveSupport::TestCase
 
   test "build_changed_surveys doesn't build twice" do
     ENV['DIR'] = 'test/fixtures/surveys'
-  
+
     assert_difference 'Survey.count', 3 do
       Rake::Task["surveyor:build_changed_surveys"].invoke
     end

--- a/test/unit/odibot_test.rb
+++ b/test/unit/odibot_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 require 'odibot'
 
 class ODIBotTest < ActiveSupport::TestCase

--- a/test/unit/presenters/certificate_presenter_test.rb
+++ b/test/unit/presenters/certificate_presenter_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../../test_helper'
 
 class CertificatePresenterTest < ActiveSupport::TestCase
 

--- a/test/unit/question_test.rb
+++ b/test/unit/question_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class QuestionTest < ActiveSupport::TestCase
   test "Question should have attributes we've added" do

--- a/test/unit/response_set_test.rb
+++ b/test/unit/response_set_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ResponseSetTest < ActiveSupport::TestCase
 

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ResponseTest < ActiveSupport::TestCase
 

--- a/test/unit/stat_test.rb
+++ b/test/unit/stat_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class StatTest < ActiveSupport::TestCase
 

--- a/test/unit/survey_section_test.rb
+++ b/test/unit/survey_section_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class SurveySectionTest < ActiveSupport::TestCase
 
@@ -17,9 +17,9 @@ class SurveySectionTest < ActiveSupport::TestCase
   test "questions_for_certificate gives questions with :question_on_certificate" do
 
     @questions = @section.questions_for_certificate @response_set
-    
+
     assert_equal [@q2], @questions
-    
+
   end
 
   # TODO

--- a/test/unit/survey_test.rb
+++ b/test/unit/survey_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class SurveyTest < ActiveSupport::TestCase
 

--- a/test/unit/transfer_test.rb
+++ b/test/unit/transfer_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class TransferTest < ActiveSupport::TestCase
 

--- a/test/unit/upload_usage_data_test.rb
+++ b/test/unit/upload_usage_data_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class UploadUsageDataTest < ActiveSupport::TestCase
   setup do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class UserTest < ActiveSupport::TestCase
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -113,4 +113,14 @@ class UserTest < ActiveSupport::TestCase
     refute User.new(email: 'robyn@example.com', password: 'password', agreed_to_terms: false).valid?
   end
 
+  test "can create a user with a valid locale" do
+    assert User.new(email: 'robyn@example.com', password: 'password', preferred_locale: 'en').valid?
+  end
+
+  test "can not create a user with a bad locale" do
+    user = User.new(email: 'robyn@example.com', password: 'password')
+    user.preferred_locale = 'moon'
+    refute user.valid?
+  end
+
 end

--- a/test/unit/verification_test.rb
+++ b/test/unit/verification_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class VerificationTest < ActiveSupport::TestCase
 
@@ -22,7 +22,7 @@ class VerificationTest < ActiveSupport::TestCase
   test "a certificate can't be validated multiple times by the same user" do
     cv = FactoryGirl.create :verification
 
-    cv2 = FactoryGirl.build :verification, 
+    cv2 = FactoryGirl.build :verification,
                              user: cv.user, certificate: cv.certificate
     assert !cv2.save
 

--- a/vendor/assets/javascripts/url.js
+++ b/vendor/assets/javascripts/url.js
@@ -1,0 +1,225 @@
+/*!
+ * Lightweight URL manipulation with JavaScript
+ * This library is independent of any other libraries and has pretty simple interface
+ * and lightweight code-base.
+ * Some ideas of query string parsing had been taken from Jan Wolter
+ * @see http://unixpapa.com/js/querystring.html
+ *
+ * @license MIT
+ * @author Mykhailo Stadnyk <mikhus@gmail.com>
+ */
+; var Url = (function() {
+	"use strict";
+
+	var
+		// mapping between what we want and <a> element properties
+		map = {
+			protocol : 'protocol',
+			host     : 'hostname',
+			port     : 'port',
+			path     : 'pathname',
+			query    : 'search',
+			hash     : 'hash'
+		},
+
+		/**
+		 * default ports as defined by http://url.spec.whatwg.org/#default-port
+		 * We need them to fix IE behavior, @see https://github.com/Mikhus/jsurl/issues/2
+		 */
+		defaultPorts = {
+			"ftp"    : 21,
+			"gopher" : 70,
+			"http"   : 80,
+			"https"  : 443,
+			"ws"     : 80,
+			"wss"    : 443
+		},
+
+		parse = function( self, url) {
+			var
+				d      = document,
+				link   = d.createElement( 'a'),
+				url    = url || d.location.href,
+				auth   = url.match( /\/\/(.*?)(?::(.*?))?@/) || []
+			;
+
+			link.href = url;
+
+			for (var i in map) {
+				self[i] = link[map[i]] || '';
+			}
+
+			// fix-up some parts
+			self.protocol = self.protocol.replace( /:$/, '');
+			self.query    = self.query.replace( /^\?/, '');
+			self.hash     = self.hash.replace( /^#/, '');
+			self.user     = auth[1] || '';
+			self.pass     = auth[2] || '';
+			self.port     = (defaultPorts[self.protocol] == self.port || self.port == 0) ? '' : self.port; // IE fix, Android browser fix
+
+			if (!self.protocol && !/^([a-z]+:)?\/\//.test( url)) { // is IE and path is relative
+				var
+					base     = new Url( d.location.href.match(/(.*\/)/)[0]),
+					basePath = base.path.split( '/'),
+					selfPath = self.path.split( '/')
+				;
+
+				basePath.pop();
+
+				for (var i = 0, props = ['protocol','user','pass','host','port'], s = props.length; i < s; i++) {
+					self[props[i]] = base[props[i]];
+				}
+
+				while (selfPath[0] == '..') { // skip all "../
+					basePath.pop();
+					selfPath.shift();
+				}
+
+				self.path = (url.substring(0, 1) != '/' ? basePath.join( '/') : '') + '/' + selfPath.join( '/');
+			}
+
+			else {
+				// fix absolute URL's path in IE
+				self.path = self.path.replace( /^\/?/, '/');
+			}
+
+			parseQs( self);
+		},
+
+		decode = function(s) {
+			s = s.replace( /\+/g, ' ');
+
+			s = s.replace( /%([ef][0-9a-f])%([89ab][0-9a-f])%([89ab][0-9a-f])/gi,
+				function( code, hex1, hex2, hex3) {
+					var
+						n1 = parseInt( hex1, 16) - 0xE0,
+						n2 = parseInt( hex2, 16) - 0x80
+					;
+
+					if (n1 == 0 && n2 < 32) {
+						return code;
+					}
+
+					var
+						n3 = parseInt( hex3, 16) - 0x80,
+						n = (n1 << 12) + (n2 << 6) + n3
+					;
+
+					if (n > 0xFFFF) {
+						return code;
+					}
+
+					return String.fromCharCode( n);
+				}
+			);
+
+			s = s.replace( /%([cd][0-9a-f])%([89ab][0-9a-f])/gi,
+				function( code, hex1, hex2) {
+					var n1 = parseInt(hex1, 16) - 0xC0;
+
+					if (n1 < 2) {
+						return code;
+					}
+
+					var n2 = parseInt(hex2, 16) - 0x80;
+
+					return String.fromCharCode( (n1 << 6) + n2);
+				}
+			);
+
+			s = s.replace( /%([0-7][0-9a-f])/gi,
+				function( code, hex) {
+					return String.fromCharCode( parseInt(hex, 16));
+				}
+			);
+
+			return s;
+		},
+
+		parseQs = function( self) {
+			var qs = self.query;
+
+			self.query = new (function( qs) {
+				var re = /([^=&]+)(=([^&]*))?/g, match;
+
+				while ((match = re.exec( qs))) {
+					var
+						key = decodeURIComponent(match[1].replace(/\+/g, ' ')),
+						value = match[3] ? decode(match[3]) : ''
+					;
+
+					if (this[key] != null) {
+						if (!(this[key] instanceof Array)) {
+							this[key] = [this[key]];
+						}
+
+						this[key].push( value);
+					}
+
+					else {
+						this[key] = value;
+					}
+				}
+
+				this.clear = function() {
+					for (key in this) {
+						if (!(this[key] instanceof Function)) {
+							delete this[key];
+						}
+					}
+				};
+
+				this.toString = function() {
+					var
+						s = '',
+						e = encodeURIComponent
+					;
+
+					for (var i in this) {
+						if (this[i] instanceof Function) {
+							continue;
+						}
+
+						if (this[i] instanceof Array) {
+							var len = this[i].length;
+
+							if (len) {
+								for (var ii = 0; ii < len; ii++) {
+									s += s ? '&' : '';
+									s += e( i) + '=' + e( this[i][ii]);
+								}
+							}
+
+							else { // parameter is an empty array, so treat as an empty argument
+								s += (s ? '&' : '') + e( i) + '=';
+							}
+						}
+
+						else {
+							s += s ? '&' : '';
+							s += e( i) + '=' + e( this[i]);
+						}
+					}
+
+					return s;
+				};
+			})( qs);
+		}
+	;
+
+	return function( url) {
+		this.toString = function() {
+			return (
+				(this.protocol && (this.protocol + '://')) +
+				(this.user && (this.user + (this.pass && (':' + this.pass)) + '@')) +
+				(this.host && this.host) +
+				(this.port && (':' + this.port)) +
+				(this.path && this.path) +
+				(this.query.toString() && ('?' + this.query)) +
+				(this.hash && ('#' + this.hash))
+			);
+		};
+
+		parse( this, url);
+	};
+}());


### PR DESCRIPTION
Add user locale switching for the whole app.

- Locale is set using the first URL parameter.
- Any page requiring a locale will redirect to the default locale if one is not found.
- User has a preferred locale that can be changed in their user profile.
- When logged-in the redirect (mentioned above) will be to their preferred locale instead of the app default.

Closes #1238