### PR TITLE
Convert survey locale changer to use site-wide locale

### DIFF
--- a/app/controllers/locale_controller.rb
+++ b/app/controllers/locale_controller.rb
@@ -1,5 +1,9 @@
 class LocaleController < ApplicationController
 
+  def change_locale
+    redirect_to params[:current_path].gsub(%r{\A/[a-z]{2}/(.*)}, "/#{params[:new_locale]}/\\1")
+  end
+
   def redirect_to_locale
     redirect_to request.fullpath.gsub(%r{\A/(.*)}, "/#{locale_for_redirect}/\\1")
   end

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -17,10 +17,7 @@ class SurveyorController < ApplicationController
   # it might be a *really* nice refactor to take this to response_set_controller#update
   # then we could use things like `form_for [surveyor, response_set] do |f|`
   def continue
-    if params[:survey_locale]
-      @response_set.update_attribute :locale, params[:survey_locale]
-
-    elsif Survey::MIGRATIONS.has_key? params[:survey_code]
+    if Survey::MIGRATIONS.has_key? params[:survey_code]
       # lets switch over to the new questionnaire
       nxt = Survey::MIGRATIONS[params[:survey_code]]
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,13 +15,6 @@ module ApplicationHelper
     Rails.env.production? ? 'https://' : request.protocol
   end
 
-  # temporarily switch to a new locale
-  def scope_locale locale
-    locale, I18n.locale = I18n.locale, locale || I18n.locale
-    yield
-    I18n.locale = locale
-  end
-
   # renders an item in the kittenData data
   def kitten_value value
     case value
@@ -117,6 +110,10 @@ module ApplicationHelper
       memo[t("locales.#{locale}")] = locale
     end
     options_for_select(locales, selected)
+  end
+
+  def current_locale_name
+    I18n.translate("locales.#{I18n.locale}")
   end
 
   # devise mapping

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -179,14 +179,6 @@ class ResponseSet < ActiveRecord::Base
     end
   end
 
-  def translation
-    survey.translations.where(locale: locale || I18n.locale).first
-  end
-
-  def locale_name
-    translation.try(:locale_name) || survey.default_locale_name || locale
-  end
-
   def modifications_allowed?
     draft?
   end

--- a/app/views/certificates/show.html.haml
+++ b/app/views/certificates/show.html.haml
@@ -14,76 +14,74 @@
             - notice = t('certificate.expiring_notice', jurisdiction: @certificate.response_set.jurisdiction, days: @certificate.days_to_expiry)
         %p= notice
 
-- scope_locale @certificate.response_set.locale do
+.certificate.hero-unit{class: "#{@certificate.attained_level}-level"}
+  - unless minimal
+    %ul.pull-right.unstyled
+      - if @certificate.needs_updating? && @certificate.owned_by?(current_user)
+        %li= link_to 'Update certificate', surveyor.continue_my_survey_path(survey_code: @certificate.survey.access_code, response_set_code: @certificate.response_set.access_code, update: true), :class => 'btn btn-small btn-info pull-right'
 
-  .certificate.hero-unit{class: "#{@certificate.attained_level}-level"}
-    - unless minimal
-      %ul.pull-right.unstyled
-        - if @certificate.needs_updating? && @certificate.owned_by?(current_user)
-          %li= link_to 'Update certificate', surveyor.continue_my_survey_path(survey_code: @certificate.survey.access_code, response_set_code: @certificate.response_set.access_code, update: true), :class => 'btn btn-small btn-info pull-right'
+      - if @certificate.published?
+        %li= link_to(t("certificates.embed_this_on_your_site"), "#embed-#{@certificate.id}", :class => 'btn btn-small btn-info pull-right', 'data-toggle' => :modal)
 
-        - if @certificate.published?
-          %li= link_to(t("certificates.embed_this_on_your_site"), "#embed-#{@certificate.id}", :class => 'btn btn-small btn-info pull-right', 'data-toggle' => :modal)
+      - if @certificate.owned_by?(current_user) || admin?
+        - if @certificate.draft?
+          %li
+            .btn.btn-small.btn-info.pull-right{disabled:'disabled'}= t 'certificate.not_yet_published'
+          %li=link_to t('certificate.edit_questionnaire'), surveyor.continue_my_survey_path(survey_code: @certificate.response_set.survey.access_code, response_set_code: @certificate.response_set.access_code), method: 'post', class: 'btn btn-small btn-info pull-left'
+      - elsif @certificate.auto_generated?
+        %li=link_to(t('certificate.claim_this_certificate'), "#claim-#{@certificate.id}", :class => 'btn btn-small btn-info', :'data-toggle' => :modal)
 
-        - if @certificate.owned_by?(current_user) || admin?
-          - if @certificate.draft?
-            %li
-              .btn.btn-small.btn-info.pull-right{disabled:'disabled'}= t 'certificate.not_yet_published'
-            %li=link_to t('certificate.edit_questionnaire'), surveyor.continue_my_survey_path(survey_code: @certificate.response_set.survey.access_code, response_set_code: @certificate.response_set.access_code), method: 'post', class: 'btn btn-small btn-info pull-left'
-        - elsif @certificate.auto_generated?
-          %li=link_to(t('certificate.claim_this_certificate'), "#claim-#{@certificate.id}", :class => 'btn btn-small btn-info', :'data-toggle' => :modal)
-
-      - content_for :modal_content do
-        =render :partial => 'shared/embed_code', :locals => {:certificate => @certificate}
-        - if @certificate.auto_generated?
-          =render :partial => 'claims/claim', :locals => {:certificate => @certificate}
+    - content_for :modal_content do
+      =render :partial => 'shared/embed_code', :locals => {:certificate => @certificate}
+      - if @certificate.auto_generated?
+        =render :partial => 'claims/claim', :locals => {:certificate => @certificate}
 
 
-    .certificate-badge.centered
+  .certificate-badge.centered
 
-    .certificate-summary
-      %p.certificate-level
-        = t("levels.#{@certificate.attained_level}.title_with_level")
-        %small
-          = t @certificate.certification_type, scope: 'certificate.certification_types'
-        %span.jurisdiction
-          %span.badge= @certificate.response_set.jurisdiction
-          %span.status= @certificate.response_set.survey.try(:status)
-      %p
-        = t("certificate.this_data_has_achieved")
-        %strong.certificate-level
-          #{t("levels.#{@certificate.attained_level}.title_with_level")}
-        = t("certificate.on_date", date: @certificate.published_at.strftime("%d %B %Y")) if @certificate.published?
-        = t("certificate.which_means")
-        = t("levels.#{@certificate.attained_level}.description")
+  .certificate-summary
+    %p.certificate-level
+      = t("levels.#{@certificate.attained_level}.title_with_level")
+      %small
+        = t @certificate.certification_type, scope: 'certificate.certification_types'
+      %span.jurisdiction
+        %span.badge= @certificate.response_set.jurisdiction
+        %span.status= @certificate.response_set.survey.try(:status)
+    %p
+      = t("certificate.this_data_has_achieved")
+      %strong.certificate-level
+        #{t("levels.#{@certificate.attained_level}.title_with_level")}
+      = t("certificate.on_date", date: @certificate.published_at.strftime("%d %B %Y")) if @certificate.published?
+      = t("certificate.which_means")
+      = t("levels.#{@certificate.attained_level}.description")
 
-    %div
-      .row
-        .span9.offset3
-          %h1= @certificate.response_set.title
+  %div
+    .row
+      .span9.offset3
+        %h1= @certificate.response_set.title
 
-  - if admin?
-    = form_for @certificate, url: dataset_certificate_path(@certificate.response_set.dataset.id, @certificate.id), html: {class: "admin-functions #{@certificate.audited ? 'admin-approved' : ''}"} do |f|
-      - if @certificate.audited
-        %i.icon-ok.icon-large
-        = t("certificate.audited")
-      - else
-        %i.icon-info-sign.icon-large
-        = t("certificate.not_audited")
+- if admin?
+  = form_for @certificate, url: dataset_certificate_path(@certificate.response_set.dataset.id, @certificate.id), html: {class: "admin-functions #{@certificate.audited ? 'admin-approved' : ''}"} do |f|
+    - if @certificate.audited
+      %i.icon-ok.icon-large
+      = t("certificate.audited")
+    - else
+      %i.icon-info-sign.icon-large
+      = t("certificate.not_audited")
 
-      = f.hidden_field :audited, value: !@certificate.audited
-      =submit_tag t(@certificate.audited ? "certificate.unmark_audited" : "certificate.mark_audited"), class: 'btn'
+    = f.hidden_field :audited, value: !@certificate.audited
+    =submit_tag t(@certificate.audited ? "certificate.unmark_audited" : "certificate.mark_audited"), class: 'btn'
 
-  - if minimal # don't show the summary
-    =render @certificate.response_set
-  - else
-    .row.certificate-content
-      .span3
-        .well.summary
-          = render 'shared/response_set_summary', response_set: @certificate.response_set
+- if minimal # don't show the summary
+  =render @certificate.response_set
+- else
+  .row.certificate-content
+    .span3
+      .well.summary
+        = render 'shared/response_set_summary', response_set: @certificate.response_set
 
-        .well.verification
-          = render 'community_verification_panel'
+      .well.verification
+        = render 'community_verification_panel'
 
-      .span9
-        = render @certificate.response_set
+    .span9
+      = render @certificate.response_set

--- a/app/views/shared/_switch_language.html.haml
+++ b/app/views/shared/_switch_language.html.haml
@@ -4,6 +4,7 @@
     %h3= t('response_set.choose_a_language')
   .modal-body
     %p= t 'response_set.language_dialog_body'
-    = form_tag surveyor.continue_my_survey_path(survey_code: response_set.survey.access_code, response_set_code: response_set.access_code), method: :post, :class => 'form-inline' do
-      = select_tag :survey_locale, options_from_collection_for_select(@response_set.survey.translations, "locale", "locale_name", @response_set.locale), prompt: t('response_set.choose_language')
+    = form_tag change_locale_path, method: :post, :class => 'form-inline' do
+      = hidden_field_tag :current_path, request.fullpath
+      = select_tag :new_locale, locale_options_for_select(I18n.locale), prompt: t('response_set.choose_language')
       = submit_tag t('response_set.start_new_language'), :class => 'btn btn-primary btn-submit'

--- a/app/views/surveyor/edit.html.haml
+++ b/app/views/surveyor/edit.html.haml
@@ -11,93 +11,92 @@
 =render :partial => 'shared/switch_jurisdiction', locals: {response_set: @response_set}
 =render :partial => 'shared/switch_language', locals: {response_set: @response_set}
 
-- scope_locale @response_set.locale do
-  = semantic_form_for(@response_set, :as => :r, :url => surveyor.update_my_survey_path, :html => {:method => :put, :id => "survey_form"}) do |f|
+= semantic_form_for(@response_set, :as => :r, :url => surveyor.update_my_survey_path, :html => {:method => :put, :id => "survey_form"}) do |f|
 
-    .affixed
-      %header
-        .container
-          .row
-            .span9
-              .jurisdiction
-                = t('surveys.jurisdiction')
-                .badge.badge-inverse=  @response_set.survey.complete_title
-                %span.status= @survey.try(:status)
-                = link_to "#switch-#{@response_set.id}", data: {toggle: :modal, content: t('dashboard.popover.change_jurisdiction') }, class: 'popdown' do
+  .affixed
+    %header
+      .container
+        .row
+          .span9
+            .jurisdiction
+              = t('surveys.jurisdiction')
+              .badge.badge-inverse=  @response_set.survey.complete_title
+              %span.status= @survey.try(:status)
+              = link_to "#switch-#{@response_set.id}", data: {toggle: :modal, content: t('dashboard.popover.change_jurisdiction') }, class: 'popdown' do
+                %i.icon.icon-pencil
+              - if @survey.translations.count > 1
+                = t('surveys.language')
+                .badge.badge-inverse= current_locale_name
+                = link_to "#switch-language-#{@response_set.id}", data:{toggle: :modal} do
                   %i.icon.icon-pencil
-                - if @survey.translations.count > 1
-                  = t('surveys.language')
-                  .badge.badge-inverse= @response_set.locale_name
-                  = link_to "#switch-language-#{@response_set.id}", data:{toggle: :modal} do
-                    %i.icon.icon-pencil
 
-              %h1{'data-bind-to-input' => @survey.meta_map[:dataset_title]}= @response_set.title
-            .span3.save-button
-              - if user_signed_in?
-                %button.btn.btn-primary.btn-large.pull-right{type: :submit, name: :finish}
-                  %i.icon-loading.icon-spin.icon-refresh.icon-large
-                  %span= t('surveyor.click_here_to_finish')
-              - else
-                =link_to t('surveyor.click_here_to_finish'), '#save-and-finish-modal', :class => 'btn btn-primary btn-large pull-right', :role=>"button", 'data-toggle' => "modal"
-                - content_for(:modal_content) do
-                  = render :partial => 'surveyor/save_and_finish_modal'
+            %h1{'data-bind-to-input' => @survey.meta_map[:dataset_title]}= @response_set.title
+          .span3.save-button
+            - if user_signed_in?
+              %button.btn.btn-primary.btn-large.pull-right{type: :submit, name: :finish}
+                %i.icon-loading.icon-spin.icon-refresh.icon-large
+                %span= t('surveyor.click_here_to_finish')
+            - else
+              =link_to t('surveyor.click_here_to_finish'), '#save-and-finish-modal', :class => 'btn btn-primary btn-large pull-right', :role=>"button", 'data-toggle' => "modal"
+              - content_for(:modal_content) do
+                = render :partial => 'surveyor/save_and_finish_modal'
 
-    = render :partial => 'status_panel'
-    = render :partial => 'shared/flashes'
+  = render :partial => 'status_panel'
+  = render :partial => 'shared/flashes'
 
-    - data = {'response-id' => @response_set.id}
-    - data['url-verified']              = t('surveyor.url_verified')
-    - data['autocompleted']             = t('surveyor.autocompleted')
-    - data['autocompleted-changed']     = t('surveyor.autocompleted_changed')
-    - data['autocompleted-explained']   = t('surveyor.autocompleted_explained')
-    - data['url-warning']               = t('surveyor.url_warning')
-    - data['autocompleted-url-warning'] = t('surveyor.autocompleted_url_warning')
-    - data['url-explained']             = t('surveyor.url_explained')
-    - data['metadata-missing']          = t('surveyor.metadata_missing')
+  - data = {'response-id' => @response_set.id}
+  - data['url-verified']              = t('surveyor.url_verified')
+  - data['autocompleted']             = t('surveyor.autocompleted')
+  - data['autocompleted-changed']     = t('surveyor.autocompleted_changed')
+  - data['autocompleted-explained']   = t('surveyor.autocompleted_explained')
+  - data['url-warning']               = t('surveyor.url_warning')
+  - data['autocompleted-url-warning'] = t('surveyor.autocompleted_url_warning')
+  - data['url-explained']             = t('surveyor.url_explained')
+  - data['metadata-missing']          = t('surveyor.metadata_missing')
 
-    - data['url-explanation']           = t('surveyor.url_explanation')
-    - data['autocomplete-explanation']  = t('surveyor.autocomplete_explanation')
+  - data['url-explanation']           = t('surveyor.url_explanation')
+  - data['autocomplete-explanation']  = t('surveyor.autocomplete_explanation')
 
-    #surveyor{class: params[:highlight_mandatory] ? 'highlight_mandatory' : '', data: data}
-      = hidden_field_tag :surveyor_javascript_enabled, false
-      - if @update
-        = hidden_field_tag :update, true
+  #surveyor{class: params[:highlight_mandatory] ? 'highlight_mandatory' : '', data: data}
+    = hidden_field_tag :surveyor_javascript_enabled, false
+    - if @update
+      = hidden_field_tag :update, true
 
-      .container.survey-intro
-        .well
+    .container.survey-intro
+      .well
+        .row-fluid
+          .span8.lead
+            != @survey.intro
+            %p
+              %a{href: about_page_url}
+                = t('surveys.read_more')
+
+        .documentation-url
+          - question = @survey.documentation_url
+          %label
+            = question.heading
           .row-fluid
-            .span8.lead
-              != @survey.intro
-              %p
-                %a{href: about_page_url}
-                  = t('surveys.read_more')
-
-          .documentation-url
-            - question = @survey.documentation_url
-            %label
-              = question.heading
-            .row-fluid
-              .span8
-                - if @response_set.documentation_url.blank?
-                  %p.url.placeholder= question.placeholder
-                  .alert.alert-error
-                    = t('surveyor.documentation_url.missing')
+            .span8
+              - if @response_set.documentation_url.blank?
+                %p.url.placeholder= question.placeholder
+                .alert.alert-error
+                  = t('surveyor.documentation_url.missing')
+              - else
+                %p.url= @response_set.documentation_url
+                - if @response_set.kitten_data && @response_set.kitten_data.data
+                  .alert.alert-success
+                    = t('surveyor.documentation_url.autocompleted')
                 - else
-                  %p.url= @response_set.documentation_url
-                  - if @response_set.kitten_data && @response_set.kitten_data.data
-                    .alert.alert-success
-                      = t('surveyor.documentation_url.autocompleted')
-                  - else
-                    .alert.alert-info
-                      = t('surveyor.documentation_url.not_autocompleted')
+                  .alert.alert-info
+                    = t('surveyor.documentation_url.not_autocompleted')
 
-              .span4
-                %a.btn.btn-large.btn-primary{href: 'start'} Edit
+            .span4
+              %a.btn.btn-large.btn-primary{href: 'start'} Edit
 
 
-      = render 'partials/dependents' unless @dependents.empty?
+    = render 'partials/dependents' unless @dependents.empty?
 
-      = render :partial => '/partials/section', :collection => @sections, :locals => {:f => f}
+    = render :partial => '/partials/section', :collection => @sections, :locals => {:f => f}
 
 - content_for(:foot_scripts) do
   :javascript

--- a/app/views/surveyor/start.html.haml
+++ b/app/views/surveyor/start.html.haml
@@ -10,63 +10,62 @@
 =render :partial => 'shared/switch_jurisdiction', locals: {response_set: @response_set}
 =render :partial => 'shared/switch_language', locals: {response_set: @response_set}
 
-- scope_locale @response_set.locale do
-  %header
-    .container
-      .row
-        .span9
-          .jurisdiction
-            = t('surveys.jurisdiction')
-            .badge.badge-inverse=  @response_set.jurisdiction
-            %span.status= @survey.try(:status)
-            = link_to "#switch-#{@response_set.id}", data: {toggle: :modal, content: t('dashboard.popover.change_jurisdiction') }, class: 'popdown' do
+%header
+  .container
+    .row
+      .span9
+        .jurisdiction
+          = t('surveys.jurisdiction')
+          .badge.badge-inverse=  @response_set.jurisdiction
+          %span.status= @survey.try(:status)
+          = link_to "#switch-#{@response_set.id}", data: {toggle: :modal, content: t('dashboard.popover.change_jurisdiction') }, class: 'popdown' do
+            %i.icon.icon-pencil
+          - if @survey.translations.count > 1
+            = t('surveys.language')
+            .badge.badge-inverse= current_locale_name
+            = link_to "#switch-language-#{@response_set.id}", data:{toggle: :modal} do
               %i.icon.icon-pencil
-            - if @survey.translations.count > 1
-              = t('surveys.language')
-              .badge.badge-inverse= @response_set.locale_name
-              = link_to "#switch-language-#{@response_set.id}", data:{toggle: :modal} do
-                %i.icon.icon-pencil
 
-          %h1{'data-bind-to-input' => @survey.meta_map[:dataset_title]}= @response_set.title
+        %h1{'data-bind-to-input' => @survey.meta_map[:dataset_title]}= @response_set.title
 
-  #surveyor
-    .container.survey-intro
-      -if @url_error and @response_set.documentation_url_explanation.blank?
-        .alert.alert-alert.flash{"data-dismiss" => "alert"}
-          %i.icon-exclamation-sign.icon-large.icon-white
-          %button.icon-remove{"data-dismiss" => "alert", :type => "button"}
-          = t('surveys.url_problem_error')
-      .well
-        .row-fluid
-          .span8.lead
-            != @survey.intro
-            %p
-              %a{href: about_page_url}
-                = t('surveys.read_more')
-
-        = semantic_form_for [surveyor, :start, @response_set] do |f|
-          - question = @survey.documentation_url
-          = f.label :documentation_url, question.heading
-
-          .row-fluid
-            .span8
-              = f.url_field :documentation_url, class: 'string', placeholder: question.placeholder, value: @response_set.documentation_url || @documentation_url
-              - explanation_class = "show" if @url_error
-              #start_url_explanation.explanation{class: explanation_class}
-                = f.input :documentation_url_explanation, as: :additional_text, label: t('surveyor.override_explanation_title'), subtitle: t('surveyor.url_explanation')
-
-              .lead
-                = t('surveys.dataset_description_html')
-            .span4
-              %button.btn.btn-large.btn-primary.submit{data:{toggle: 'popover', placement: 'bottom', content: t('surveys.url_problem_error'), error: t('surveys.url_unknown_error')}}
-                %i.icon-loading.icon-spin.icon-refresh
-                %i.icon-exclamation-sign
-                = t('surveys.check_url_button')
-
+#surveyor
+  .container.survey-intro
+    -if @url_error and @response_set.documentation_url_explanation.blank?
+      .alert.alert-alert.flash{"data-dismiss" => "alert"}
+        %i.icon-exclamation-sign.icon-large.icon-white
+        %button.icon-remove{"data-dismiss" => "alert", :type => "button"}
+        = t('surveys.url_problem_error')
+    .well
+      .row-fluid
+        .span8.lead
+          != @survey.intro
           %p
-            = t('surveys.do_not_have_url')
-            %a.btn{href: 'take'}
-              = t('surveys.skip_this_button')
+            %a{href: about_page_url}
+              = t('surveys.read_more')
+
+      = semantic_form_for [surveyor, :start, @response_set] do |f|
+        - question = @survey.documentation_url
+        = f.label :documentation_url, question.heading
+
+        .row-fluid
+          .span8
+            = f.url_field :documentation_url, class: 'string', placeholder: question.placeholder, value: @response_set.documentation_url || @documentation_url
+            - explanation_class = "show" if @url_error
+            #start_url_explanation.explanation{class: explanation_class}
+              = f.input :documentation_url_explanation, as: :additional_text, label: t('surveyor.override_explanation_title'), subtitle: t('surveyor.url_explanation')
+
+            .lead
+              = t('surveys.dataset_description_html')
+          .span4
+            %button.btn.btn-large.btn-primary.submit{data:{toggle: 'popover', placement: 'bottom', content: t('surveys.url_problem_error'), error: t('surveys.url_unknown_error')}}
+              %i.icon-loading.icon-spin.icon-refresh
+              %i.icon-exclamation-sign
+              = t('surveys.check_url_button')
+
+        %p
+          = t('surveys.do_not_have_url')
+          %a.btn{href: 'take'}
+            = t('surveys.skip_this_button')
 
 
 / #surveyor fieldset ol li label, #surveyor fieldset ol li input

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,8 @@ OpenDataCertificate::Application.routes.draw do
 
   get 'status/ping' => 'main#ping'
 
+  post :change_locale, to: 'locale#change_locale'
+
   match '(*path)', to: 'locale#redirect_to_locale', constraints: ->(request) {
     !request.params[:path] || !request.params[:path].start_with?(*I18n.available_locales.map(&:to_s))
   }

--- a/db/migrate/20151006100913_remove_locale_from_response_sets.rb
+++ b/db/migrate/20151006100913_remove_locale_from_response_sets.rb
@@ -1,0 +1,9 @@
+class RemoveLocaleFromResponseSets < ActiveRecord::Migration
+  def up
+    remove_column :response_sets, :locale
+  end
+
+  def down
+    add_column :response_sets, :locale, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150929145945) do
+ActiveRecord::Schema.define(:version => 20151006100913) do
 
   create_table "answers", :force => true do |t|
     t.integer  "question_id"
@@ -254,7 +254,6 @@ ActiveRecord::Schema.define(:version => 20150929145945) do
     t.integer  "dataset_id"
     t.string   "aasm_state",        :default => "draft"
     t.integer  "attained_index"
-    t.string   "locale"
     t.string   "missing_responses", :default => ""
   end
 

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -2,19 +2,6 @@
 require_relative '../../test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
-  test 'scopes the locale' do
-    I18n.locale = :en
-    called = false
-
-    scope_locale :fr do
-      assert_equal :fr, I18n.locale
-      called = true
-    end
-
-    assert_equal :en, I18n.locale
-    assert called
-  end
-
   test 'converts markdown' do
 
     source = '**hello** world'


### PR DESCRIPTION
Annoyingly route url helpers don't work completely with Rails Engines, so I had to resort to a simple regex find and replace for the redirect.

Hopefully some nice cleanup here otherwise though. Much more consistent now, and I was able to remove `locale` from `response_sets` entirely and clean up some other helper methods too.

**[Click here](https://github.com/theodi/open-data-certificate/pull/1286/files?w=1)** to view files excluding whitespace changes. Lots of re-indented lines.