### PR TITLE
Handle missing data on legacy KittenData instances

### DIFF
--- a/app/models/kitten_data.rb
+++ b/app/models/kitten_data.rb
@@ -45,7 +45,7 @@ class KittenData < ActiveRecord::Base
   end
 
   def assumed_us_public_domain?
-    data.fetch(:assumptions, []).include?(:us_public_domain)
+    data.fetch(:assumptions, []).include?(:us_public_domain) if data
   end
 
   def distributions

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -41,6 +41,8 @@ class ResponseSet < ActiveRecord::Base
 
   scope :published, where(:aasm_state => 'published')
 
+  delegate :assumed_us_public_domain?, to: :kitten_data, allow_nil: true
+
   # Checks if a value is blank by Surveyor's standards
   def self.is_blank_value?(value)
     value.is_a?(Array) ? value.all?{|values| values.blank? } : value.to_s.blank?

--- a/app/views/response_sets/_response_set.html.haml
+++ b/app/views/response_sets/_response_set.html.haml
@@ -10,7 +10,7 @@
     - if responses.any?
       %hr.heavy
       %h3= section.title
-      - if section.reference_identifier == "legal" && response_set.kitten_data.assumed_us_public_domain?
+      - if section.reference_identifier == "legal" && response_set.assumed_us_public_domain?
         %div.certificate-info
           %i.icon-info-sign
           = t('certificate.us_public_domain_assumption_html')

--- a/test/unit/kitten_data_test.rb
+++ b/test/unit/kitten_data_test.rb
@@ -456,6 +456,12 @@ class KittenDataTest < ActiveSupport::TestCase
     refute kitten_data.assumed_us_public_domain?
   end
 
+  test 'assumed_us_public_domain does not crash on old kitten data instances' do
+    #kitten_data = KittenData.new(url: 'http://catalog.data.gov/some_data')
+    kitten_data.data = false # old versions stored false instead of {}
+    refute kitten_data.assumed_us_public_domain?
+  end
+
   %w[us-pd other-pd notspecified].each do |license_id|
     test "data.gov assumptions are set for federal organizations with #{license_id} license" do
       set_us_data


### PR DESCRIPTION
Got caught out again by `data` being `false` instead of `{}` on older KittenData instances again.