### PR TITLE
Check url generation for datasets.csv exporter

### DIFF
--- a/app/exporters/datasets_csv.rb
+++ b/app/exporters/datasets_csv.rb
@@ -48,7 +48,8 @@ class DatasetsCSV
   def url(name, dataset, params={})
     params = {
       host: OpenDataCertificate.hostname,
-      protocol: Rails.env.production? ? 'https' : 'http'
+      protocol: Rails.env.production? ? 'https' : 'http',
+      locale: I18n.locale
     }.merge(params)
     Rails.application.routes.url_helpers.send(name, dataset, params)
   end

--- a/spec/exporters/datasets_csv_spec.rb
+++ b/spec/exporters/datasets_csv_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe DatasetsCSV do
+
+  subject(:exporter) { DatasetsCSV.new(Dataset) }
+
+  it 'generates a url for a dataset' do
+    response_set = FactoryGirl.create(:response_set_with_dataset)
+    url = exporter.url(:dataset_url, response_set.dataset)
+    expect(url).to end_with(dataset_path(response_set.dataset, locale: 'en'))
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 ActiveRecord::Base.mass_assignment_sanitizer = :strict
 
 RSpec.configure do |config|
+  config.include Rails.application.routes.url_helpers
   config.include JsonSpec::Helpers
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.mock_with :rspec


### PR DESCRIPTION
The static file generator for the dataset.csv exporter was failing as it wasn't providing the locale in the url params