### PR TITLE
Finish job early if generator has already run

### DIFF
--- a/app/workers/certificate_generator_worker.rb
+++ b/app/workers/certificate_generator_worker.rb
@@ -4,7 +4,9 @@ class CertificateGeneratorWorker
   def perform(certificate_generator_id, jurisdiction, create_user, dataset_id)
     generator = CertificateGenerator.find(certificate_generator_id)
     dataset = Dataset.find_by_id dataset_id
-    generator.generate(jurisdiction, create_user, dataset)
+    unless generator.completed?
+      generator.generate(jurisdiction, create_user, dataset)
+    end
   end
 
 end


### PR DESCRIPTION
If the generator has already run (sidekiq can sometimes attempt to start
a job more than once*) then don’t try again as trying to publish an
already published `ResponseSet` will fail due to state machine rules.


\* due to CAP