### PR TITLE
Fix CORS config to use locale path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -96,8 +96,8 @@ module OpenDataCertificate
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'
-        resource '/datasets/*.json', :headers => :any, :methods => [:get, :options]
-        resource '/datasets/*.js', :headers => :any, :methods => [:get, :options]
+        resource '/*/datasets/*.json', :headers => :any, :methods => [:get, :options]
+        resource '/*/datasets/*.js', :headers => :any, :methods => [:get, :options]
       end
     end
 

--- a/spec/requests/cors_request_spec.rb
+++ b/spec/requests/cors_request_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../spec_helper'
+
+describe 'CORS request' do
+
+  context 'for the homepage' do
+    it 'does not respond with Access-Control-Allow-Origin' do
+      get '/en', nil, {'HTTP_ORIGIN' => 'http://example.com'}
+      expect(response.headers['Access-Control-Allow-Origin']).to be_nil
+    end
+  end
+
+  context 'CertificatesController#badge' do
+    let(:dataset) { FactoryGirl.create(:dataset) }
+
+    it 'returns Access-Control-Allow-Origin header' do
+      get "/en/datasets/#{dataset.id}/certificate/badge.js", nil, {'HTTP_ORIGIN' => 'http://example.com'}
+      expect(response.headers['Access-Control-Allow-Origin']).to eql('http://example.com')
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes the issue raised in #1310. CORS config was not respecting the new URLs.

Probably want to get this into production because it's affecting real users.

(Closes #1310)