### PR TITLE
Add special locales in development and test

### DIFF
--- a/config/initializers/i18n_custom_backend.rb
+++ b/config/initializers/i18n_custom_backend.rb
@@ -1,0 +1,25 @@
+module OdiI18nBackend
+  def store_translations(locale, data, options={})
+    super(locale, data, options)
+    super('db', deep_duplicate_locale_strings(data), options) if locale == 'en'
+  end
+
+  def deep_duplicate_locale_strings(data)
+    data.inject({}) do |result, (k,v)|
+      unless v.blank?
+        result[k] = if v.is_a?(Hash)
+          deep_duplicate_locale_strings(v)
+        elsif v.is_a?(String)
+          "#{v} #{v}"
+        else
+          v
+        end
+      end
+      result
+    end
+  end
+end
+
+unless Rails.env.production?
+  I18n::Backend::Simple.include(OdiI18nBackend)
+end

--- a/config/initializers/i18n_custom_backend.rb
+++ b/config/initializers/i18n_custom_backend.rb
@@ -1,16 +1,29 @@
 module OdiI18nBackend
   def store_translations(locale, data, options={})
     super(locale, data, options)
-    super('db', deep_duplicate_locale_strings(data), options) if locale == 'en'
+    super('db', duplicate_locale_strings(data), options) if locale == 'en'
+    super('bl', underscore_locale_strings(data), options) if locale == 'en'
   end
 
-  def deep_duplicate_locale_strings(data)
+  def duplicate_locale_strings(data)
+    deep_transform_locale_strings(data) do |locale_string|
+      "#{locale_string} #{locale_string}"
+    end
+  end
+
+  def underscore_locale_strings(data)
+    deep_transform_locale_strings(data) do |locale_string|
+      locale_string.gsub(/[^\s]/, '_')
+    end
+  end
+
+  def deep_transform_locale_strings(data, &block)
     data.inject({}) do |result, (k,v)|
       unless v.blank?
         result[k] = if v.is_a?(Hash)
-          deep_duplicate_locale_strings(v)
+          deep_transform_locale_strings(v, &block)
         elsif v.is_a?(String)
-          "#{v} #{v}"
+          block.call(v)
         else
           v
         end


### PR DESCRIPTION
Added two special locales, in development and test environments only, designed to aid debugging of i18n issues.

1. Doubled-up-English locale (/db/). Designed for testing styling issues easily in languages that might turn out to be much longer than English text when translated. This can be used as a debugging tool for #1288.
2. Blank/underscore locale (/bl/). Converts all translated text to underscores, so it is easy to see text without translations.