### PR TITLE
Fix typo: Remove duplicate word 'anyone'

### DIFF
--- a/prototype/jurisdictions/certificate.GB.xml
+++ b/prototype/jurisdictions/certificate.GB.xml
@@ -40,7 +40,7 @@
 				</radioset>
 				<help>If your organisation did not originally create or gather this data then you may not have the right to publish it as open data. If you are not sure, please check with the data owner for their permission.
 				<br/>
-				Open data is data that anyone anyone can access, use and share – subject only, at most, to the requirement to attribute and share-alike – see our page explaining ‘<a href="https://theodi.org/what-is-open-data">what is open data?</a>’ and the <a href="http://opendefinition.org">open definition</a> for more details.</help>
+				Open data is data that anyone can access, use and share – subject only, at most, to the requirement to attribute and share-alike – see our page explaining ‘<a href="https://theodi.org/what-is-open-data">what is open data?</a>’ and the <a href="http://opendefinition.org">open definition</a> for more details.</help>
 				<if test="this.publisherRights() === 'no'">
 					<requirement>You must have the <strong>right to publish this data</strong>.</requirement>
 				</if>

--- a/surveys/definition/questionnaire.jurisdiction.CZ.xml
+++ b/surveys/definition/questionnaire.jurisdiction.CZ.xml
@@ -37,7 +37,7 @@
 				</radioset>
 				<help>If your organisation did not originally create or gather this data then you may not have the right to publish it as open data. If you are not sure, please check with the data owner for their permission.
 				<br/>
-				Open data is data that anyone anyone can access, use and share – subject only, at most, to the requirement to attribute and share-alike – see our page explaining ‘<a href="https://theodi.org/what-is-open-data">what is open data?</a>’ and the <a href="http://opendefinition.org">open definition</a> for more details.</help>
+				Open data is data that anyone can access, use and share – subject only, at most, to the requirement to attribute and share-alike – see our page explaining ‘<a href="https://theodi.org/what-is-open-data">what is open data?</a>’ and the <a href="http://opendefinition.org">open definition</a> for more details.</help>
 				<if test="this.publisherRights() === 'no'">
 					<requirement>You must have the <strong>right to publish this data</strong>.</requirement>
 				</if>

--- a/surveys/generated/locales/surveys.en.yml
+++ b/surveys/generated/locales/surveys.en.yml
@@ -1450,9 +1450,6 @@ en:
           cc_zero:
             text: Creative Commons CCZero
             text_as_statement: Creative Commons CCZero
-          ogl_uk:
-            text: UK Open Government Licence
-            text_as_statement: UK Open Government Licence
           odc_by:
             text: Open Data Commons Attribution License
             text_as_statement: Open Data Commons Attribution License
@@ -1469,6 +1466,15 @@ en:
           other:
             text: Other...
             text_as_statement: ''
+          ogl_uk:
+            text: UK Open Government Licence
+            text_as_statement: UK Open Government Licence
+          iodl:
+            text: Italian Open Data License v1.0
+            text_as_statement: Italian Open Data License v1.0
+          iodl_2_0:
+            text: Italian Open Data License v2.0
+            text_as_statement: Italian Open Data License v2.0
       dataNotApplicable:
         text: Why doesn't a licence apply to this data?
         text_as_statement: This data is not licensed because
@@ -1600,15 +1606,21 @@ en:
           cc_zero:
             text: Creative Commons CCZero
             text_as_statement: Creative Commons CCZero
-          ogl_uk:
-            text: UK Open Government Licence
-            text_as_statement: UK Open Government Licence
           na:
             text: Not applicable
             text_as_statement: ''
           other:
             text: Other...
             text_as_statement: ''
+          ogl_uk:
+            text: UK Open Government Licence
+            text_as_statement: UK Open Government Licence
+          iodl:
+            text: Italian Open Data License v1.0
+            text_as_statement: Italian Open Data License v1.0
+          iodl_2_0:
+            text: Italian Open Data License v2.0
+            text_as_statement: Italian Open Data License v2.0
       contentNotApplicable:
         text: Why doesn't a licence apply to the content of the data?
         text_as_statement: The content in this data is not licensed because
@@ -1688,6 +1700,40 @@ en:
         answers:
           a_1:
             placeholder: Content Rights Description URL
+      riskAssessmentExists:
+        text: Have you assessed the risks of disclosing personal data?
+        text_as_statement: The curator has
+        help_text: A risk assessment measures risks to the privacy of individuals
+          in your data as well as the use and disclosure of that information.
+        answers:
+          a_false:
+            text: 'no'
+            text_as_statement: not carried out a privacy risk assessment
+          a_true:
+            text: 'yes'
+            text_as_statement: carried out a privacy risk assessment
+      riskAssessmentUrl:
+        text: Where is your risk assessment published?
+        text_as_statement: The risk assessment is published at
+        help_text: Give a URL to where people can check how you have assessed the
+          privacy risks to individuals. This may be redacted or summarised if it contains
+          sensitive information.
+        answers:
+          a_1:
+            placeholder: Risk Assessment URL
+      riskAssessmentAudited:
+        text: Has your risk assessment been independently audited?
+        text_as_statement: The risk assessment has been
+        help_text: It's good practice to check your risk assessment was done correctly.
+          Independent audits by specialists or third-parties tend to be more rigorous
+          and impartial.
+        answers:
+          a_false:
+            text: 'no'
+            text_as_statement: ''
+          a_true:
+            text: 'yes'
+            text_as_statement: independently audited
       usGovData:
         text: Was the data created by the US Government?
         help_text: If the data was created by the US Government, and you are in the
@@ -1748,40 +1794,6 @@ en:
               people or organisations. Information about rights needs to be kept in
               the data too.
             text_as_statement: ''
-      riskAssessmentExists:
-        text: Have you assessed the risks of disclosing personal data?
-        text_as_statement: The curator has
-        help_text: A risk assessment measures risks to the privacy of individuals
-          in your data as well as the use and disclosure of that information.
-        answers:
-          a_false:
-            text: 'no'
-            text_as_statement: not carried out a privacy risk assessment
-          a_true:
-            text: 'yes'
-            text_as_statement: carried out a privacy risk assessment
-      riskAssessmentUrl:
-        text: Where is your risk assessment published?
-        text_as_statement: The risk assessment is published at
-        help_text: Give a URL to where people can check how you have assessed the
-          privacy risks to individuals. This may be redacted or summarised if it contains
-          sensitive information.
-        answers:
-          a_1:
-            placeholder: Risk Assessment URL
-      riskAssessmentAudited:
-        text: Has your risk assessment been independently audited?
-        text_as_statement: The risk assessment has been
-        help_text: It's good practice to check your risk assessment was done correctly.
-          Independent audits by specialists or third-parties tend to be more rigorous
-          and impartial.
-        answers:
-          a_false:
-            text: 'no'
-            text_as_statement: ''
-          a_true:
-            text: 'yes'
-            text_as_statement: independently audited
     labels:
       findability:
         text: Findability

--- a/surveys/generated/surveyor/odc_questionnaire.CZ.rb
+++ b/surveys/generated/surveyor/odc_questionnaire.CZ.rb
@@ -89,7 +89,7 @@ survey 'CZ',
       :discussion_topic => :cz_publisherRights,
       :help_text => 'If your organisation did not originally create or gather this data then you may not have the right to publish it as open data. If you are not sure, please check with the data owner for their permission.
 				<br/>
-				Open data is data that anyone anyone can access, use and share – subject only, at most, to the requirement to attribute and share-alike – see our page explaining ‘<a href="https://theodi.org/what-is-open-data">what is open data?</a>’ and the <a href="http://opendefinition.org">open definition</a> for more details.',
+				Open data is data that anyone can access, use and share – subject only, at most, to the requirement to attribute and share-alike – see our page explaining ‘<a href="https://theodi.org/what-is-open-data">what is open data?</a>’ and the <a href="http://opendefinition.org">open definition</a> for more details.',
       :requirement => ['basic_2'],
       :pick => :one,
       :required => :required

--- a/surveys/generated/surveyor/odc_questionnaire.GB.rb
+++ b/surveys/generated/surveyor/odc_questionnaire.GB.rb
@@ -90,7 +90,7 @@ survey 'GB',
       :discussion_topic => :gb_publisherRights,
       :help_text => 'If your organisation did not originally create or gather this data then you may not have the right to publish it as open data. If you are not sure, please check with the data owner for their permission.
 				<br/>
-				Open data is data that anyone anyone can access, use and share – subject only, at most, to the requirement to attribute and share-alike – see our page explaining ‘<a href="https://theodi.org/what-is-open-data">what is open data?</a>’ and the <a href="http://opendefinition.org">open definition</a> for more details.',
+				Open data is data that anyone can access, use and share – subject only, at most, to the requirement to attribute and share-alike – see our page explaining ‘<a href="https://theodi.org/what-is-open-data">what is open data?</a>’ and the <a href="http://opendefinition.org">open definition</a> for more details.',
       :requirement => ['basic_2'],
       :pick => :one,
       :required => :required

--- a/surveys/translations/questionnaire.jurisdiction.CZ.en.yml
+++ b/surveys/translations/questionnaire.jurisdiction.CZ.en.yml
@@ -12,7 +12,7 @@ en:
       text: "Do you have the right to make this data open?"
       help_text: "If your organisation did not originally create or gather this data then you may not have the right to publish it as open data. If you are not sure, please check with the data owner for their permission.
 				<br/>
-				Open data is data that anyone anyone can access, use and share – subject only, at most, to the requirement to attribute and share-alike – see our page explaining ‘<a href=\"https://theodi.org/what-is-open-data\">what is open data?</a>’ and the <a href=\"http://opendefinition.org\">open definition</a> for more details."
+				Open data is data that anyone can access, use and share – subject only, at most, to the requirement to attribute and share-alike – see our page explaining ‘<a href=\"https://theodi.org/what-is-open-data\">what is open data?</a>’ and the <a href=\"http://opendefinition.org\">open definition</a> for more details."
       answers:
         "yes":
           text: "yes, you have the rights to open this data up"


### PR DESCRIPTION
Don't think this actually affects anything visible anymore, but just tidying up some of the issue backlog.

Closes #1213