### PR TITLE
Set a default and validate Certificate#attained_level

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -2,8 +2,6 @@ class Certificate < ActiveRecord::Base
   include Badges, Counts, Ownership
   include AASM
 
-  after_initialize :init
-
   belongs_to :response_set, touch: true, inverse_of: :certificate
 
   has_one :survey,  through: :response_set
@@ -84,10 +82,6 @@ class Certificate < ActiveRecord::Base
     event :draft do
       transitions from: :published, to: :draft
     end
-  end
-
-  def init
-    self.attained_level ||= 'none'
   end
 
   def visible?

--- a/db/migrate/20151102173434_set_default_certificate_attained_level.rb
+++ b/db/migrate/20151102173434_set_default_certificate_attained_level.rb
@@ -1,0 +1,5 @@
+class SetDefaultCertificateAttainedLevel < ActiveRecord::Migration
+  def up
+    Certificate.where('attained_level is null').update_all(attained_level: 'none')
+  end
+end

--- a/db/migrate/20151102173434_set_default_certificate_attained_level.rb
+++ b/db/migrate/20151102173434_set_default_certificate_attained_level.rb
@@ -2,4 +2,7 @@ class SetDefaultCertificateAttainedLevel < ActiveRecord::Migration
   def up
     Certificate.where('attained_level is null').update_all(attained_level: 'none')
   end
+
+  def down
+  end
 end

--- a/db/migrate/20151105153400_set_default_value_for_certificate_attained_level.rb
+++ b/db/migrate/20151105153400_set_default_value_for_certificate_attained_level.rb
@@ -1,0 +1,8 @@
+class SetDefaultValueForCertificateAttainedLevel < ActiveRecord::Migration
+  def up
+    change_column_default :certificates, :attained_level, 'none'
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151103121302) do
+ActiveRecord::Schema.define(:version => 20151105153400) do
 
   create_table "answers", :force => true do |t|
     t.integer  "question_id"
@@ -67,9 +67,9 @@ ActiveRecord::Schema.define(:version => 20151103121302) do
   create_table "certificates", :force => true do |t|
     t.integer  "response_set_id"
     t.text     "name"
-    t.datetime "created_at",                         :null => false
-    t.datetime "updated_at",                         :null => false
-    t.string   "attained_level"
+    t.datetime "created_at",                          :null => false
+    t.datetime "updated_at",                          :null => false
+    t.string   "attained_level",  :default => "none"
     t.string   "curator"
     t.boolean  "published",       :default => false
     t.datetime "expires_at"

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../spec_helper'
+
+describe Certificate do
+
+  describe '#attained_level' do
+    it "starts out as 'none'" do
+      cert = Certificate.new
+      expect(cert.attained_level).to eql('none')
+    end
+
+    it 'cannot be saved as nil' do
+      cert = FactoryGirl.create(:certificate)
+      cert.attained_level = nil
+      expect {
+        cert.save!
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+end


### PR DESCRIPTION
`Certificate#attained_level` is always assumed to have a sensible value elsewhere in the code, but is often `null` in the database. For example, used to look up the correct translation for display on the certificate view. 