### PR TITLE
Make sure update_from_response_set always gets called

### DIFF
--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -344,7 +344,6 @@ class ResponseSet < ActiveRecord::Base
       end
     end
     update_from_ui_hash(ui_hash)
-    post_responses_update
   end
 
   # Updates responses without using a surveyor form
@@ -392,10 +391,10 @@ class ResponseSet < ActiveRecord::Base
     end
 
     update_from_ui_hash(Hash[ui_hash.map.with_index { |value, i| [i.to_s, value] }])
-    post_responses_update
   end
 
-  def post_responses_update
+  def update_from_ui_hash(ui_hash)
+    super
     certificate.update_from_response_set
     dataset.set_default_title!(dataset_title_determined_from_responses)
     dataset.set_default_documentation_url!(dataset_documentation_url_determined_from_responses)


### PR DESCRIPTION
Our current woes were caused by the fact that `update_from_response_set` was only getting called when a certificate was getting updated. I've fixed this by overriding the `update_from_ui_hash` method (which is defined in Surveyor) and calling the logic which was called in `post_responses_update` after the `update_from_ui_hash` logic is called