### PR TITLE
Never. Bundle. Again

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.vendor
+.bundle
+log/*
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:2.1
+
+RUN bundle config --global frozen 1
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app
+COPY Gemfile.lock /usr/src/app
+COPY vendor/gems/ /usr/src/app/vendor/gems
+
+RUN bundle install
+
+COPY . /usr/src/app
+
+EXPOSE 3000
+
+CMD [ "bundle", "exec", "rails", "server" ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ full details.
 #### Under Docker
 
 1. Install [Docker Toolbox](https://www.docker.com/products/docker-toolbox)
+  * Set up a Docker host with `docker-machine start default` or use Kitematic GUI
+  * Make sure your terminal can talk to Docker
+    * either by opening the 'Docker Quikstart Terminal'
+    * or adding `eval $(docker-machine env default)` to your `.bashrc`
 2. run `bin/dockerize`
 3. make tea
 4. everything should be set up and be open in your browser.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ full details.
 
 ### Running
 
+#### Under Docker
+
+1. Install [Docker Toolbox](https://www.docker.com/products/docker-toolbox)
+2. run `bin/dockerize`
+3. make tea
+4. everything should be set up and be open in your browser.
+
+Tests can be run inside a container too with:
+
+    docker-compose run web bundle exec rake test
+
+#### In a traditional dev environment
+
 ```bash
 # this will setup a default admin user (test@example.com) and
 # load the GB survey

--- a/bin/dockerize
+++ b/bin/dockerize
@@ -23,5 +23,4 @@ fi
 
 docker-compose up -d web sidekiq delayed_job
 
-while ! nc -z $(docker-machine ip default) 3000; do sleep 1; done
-open "http://$(docker-machine ip default):3000"
+bin/open

--- a/bin/dockerize
+++ b/bin/dockerize
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ ! -e .env ]
+then
+  bash docker/env.template > .env
+fi
+
+rm tmp/pids/*
+docker-compose build
+docker-compose up -d
+
+if [ ! -e config/database.yml ]
+then
+  cp docker/database.yml.example config/database.yml
+  docker-compose run web bundle exec rake db:create db:schema:load db:seed
+fi
+
+open "http://$(docker-machine ip default):3000"

--- a/bin/dockerize
+++ b/bin/dockerize
@@ -5,14 +5,23 @@ then
   bash docker/env.template > .env
 fi
 
-rm tmp/pids/*
-docker-compose build
-docker-compose up -d
+rm -f tmp/pids/*
+docker-compose up -d mysql redis
 
 if [ ! -e config/database.yml ]
 then
   cp docker/database.yml.example config/database.yml
+  first_run="yes"
+fi
+
+docker-compose build
+
+if [ "$first_run" == "yes" ]
+then
   docker-compose run web bundle exec rake db:create db:schema:load db:seed
 fi
 
+docker-compose up -d web sidekiq delayed_job
+
+while ! nc -z $(docker-machine ip default) 3000; do sleep 1; done
 open "http://$(docker-machine ip default):3000"

--- a/bin/dockerize
+++ b/bin/dockerize
@@ -18,7 +18,7 @@ docker-compose build
 
 if [ "$first_run" == "yes" ]
 then
-  docker-compose run web bundle exec rake db:create db:schema:load db:seed
+  docker-compose run --rm web bundle exec rake db:create db:schema:load db:seed
 fi
 
 docker-compose up -d web sidekiq delayed_job

--- a/bin/open
+++ b/bin/open
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+port="$(docker-compose port web 3000 | cut -d: -f2)"
+while ! nc -z $(docker-machine ip default) $port; do sleep 1; done
+open "http://$(docker-machine ip default):$port"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 services:
   web:
+    image: certificates
     build: .
     ports:
       - "3000:3000"
@@ -9,6 +10,18 @@ services:
     depends_on:
       - redis
       - mysql
+  sidekiq:
+    image: certificates
+    depends_on:
+      - redis
+      - mysql
+    command: ["bundle", "exec", "sidekiq", "-c", "3"]
+  delayed_job:
+    image: certificates
+    depends_on:
+      - redis
+      - mysql
+    command: ["bundle", "exec", "rake", "jobs:work"]
   redis:
     image: redis
   mysql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - ".:/usr/src/app"
+    depends_on:
+      - redis
+      - mysql
+  redis:
+    image: redis
+  mysql:
+    environment:
+      MYSQL_ROOT_PASSWORD: secretsquirrel
+    image: mysql:5.5.48

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,14 @@ services:
   redis:
     image: redis
   mysql:
+    image: mysql:5.5.48
     environment:
       MYSQL_ROOT_PASSWORD: secretsquirrel
-    image: mysql:5.5.48
+      MYSQL_USER: theodi
+      MYSQL_PASSWORD: secretsquirrel
+      MYSQL_DATABASE: certificates_development
+    volumes:
+      - mysqldata:/var/lib/mysql
+volumes:
+  mysqldata:
+    driver: local

--- a/docker/database.yml.example
+++ b/docker/database.yml.example
@@ -1,0 +1,19 @@
+development:
+  adapter: mysql2
+  host: mysql
+  port: 3306
+  encoding: utf8
+  username: root
+  password: secretsquirrel
+  database: certificates_development
+  pool: 5
+  timeout: 5000
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: sqlite3
+  database: db/test.sqlite3
+  pool: 5
+  timeout: 5000

--- a/docker/env.template
+++ b/docker/env.template
@@ -1,0 +1,3 @@
+echo "export ODC_REDIS_SERVER_URL=\"redis://redis:6379\""
+# This is the only place where the external port has to be hard coded
+echo "export CERTIFICATE_HOSTNAME=\"$(docker-machine ip default):3000\""


### PR DESCRIPTION
Run Certificates in Docker.

I've created a `Dockerfile` which the app can run in based on the default `ruby` image and set up a
`docker-compose.yml` file that links the required `redis` and `mysql` services.

Running `bin/dockerize` will set everything up and open the app in your default browser.

**Instructions**

1. Install [Docker Toolbox](https://www.docker.com/products/docker-toolbox)
  * Set up a Docker host with `docker-machine start default` or use Kitematic GUI
  * Make sure your terminal can talk to Docker
    * either by opening the 'Docker Quikstart Terminal'
    * or adding `eval $(docker-machine env default)` to your `.bashrc`
2. run `bin/dockerize`
3. make tea
4. everything should be set up and be open in your browser.

Tests can be run inside a container too with:

    docker-compose run --rm web bundle exec rake test

Once `bin/dockerize` has been run you can stop the system with:

    docker-compose down

and start it again with:

    docker-compose up -d

and open in your browser with:

    bin/open