### PR TITLE
Campaign uifix

### DIFF
--- a/app/assets/javascripts/campaign.js
+++ b/app/assets/javascripts/campaign.js
@@ -192,7 +192,7 @@ $(document).ready(function($){
 
   $('div#tags-subset,div#organization-subset').hide();
   $('div#tags-subset,div#organization-subset').off().click(function(e){ 
-    $(this).children('input').val(''); $(this).hide();
+    $(this).find('input').val(''); $(this).hide();
     resetStartButtons();
   });
 

--- a/app/assets/javascripts/campaign.js
+++ b/app/assets/javascripts/campaign.js
@@ -135,6 +135,7 @@ $(document).ready(function($){
       data: { 
         campaign_url: $('#certification_campaign_url').val(),
         jurisdiciton: $('#certification_campaign_jurisdiction').val(),
+        limit: $('#certification_campaign_limit').val(),
         subset: { 
           organization: $('#organization-subset input').val(), tags: $('#tags-subset input').val() 
         }

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -103,13 +103,15 @@ class CampaignsController < ApplicationController
   end
 
   def precheck
+    limit = params["limit"].blank? ? nil : params["limit"].to_i
     campaign = current_user.certification_campaigns.build(url: params.fetch("campaign_url"), 
-      subset: params.fetch("subset"))
-
+      subset: params.fetch("subset"), limit: limit)
     factory = CertificateFactory::CKANFactory.new({ is_prefetch: true, campaign: campaign, rows:3, params:{} })
     @generators = factory.prebuild
+
     @result_count = factory.result_count
-    
+    @result_count = limit if !limit.blank? and (limit < @result_count)
+
     respond_to do |format|
       format.js
     end


### PR DESCRIPTION
Fixes the following two bugs on the campaign UI: 

- tester was not taking into account the dataset limit
- un-selecting subsets wasn't blanking the input