### PR TITLE
Prevents no method error arising from unpublished certs while browsing datasets

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -25,7 +25,7 @@ class DatasetsController < ApplicationController
 
     datasets = Dataset.visible
                 .includes(:response_set)
-                .joins(:certificate).where('certificates.published = true')
+                .joins(:certificate).where(certificates: { published: true })
                 .order('certificates.published_at DESC')
 
     @title = t('datasets.datasets')

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -23,9 +23,9 @@ class DatasetsController < ApplicationController
 
   def index
 
-    datasets = Dataset
-                .visible
-                .includes(:response_set, :certificate)
+    datasets = Dataset.visible
+                .includes(:response_set)
+                .joins(:certificate).where('certificates.published = true')
                 .order('certificates.published_at DESC')
 
     @title = t('datasets.datasets')


### PR DESCRIPTION
`/datasets` was giving `'undefined method `year' for nil:NilClass` as it was selecting unpublished records

