### PR TITLE
No robots

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,10 @@ class User < ActiveRecord::Base
   validates :agreed_to_terms, acceptance: {accept: true}, allow_nil: true
   validates :preferred_locale, inclusion: {in: I18n.available_locales.map(&:to_s)}
 
+  # Spam filtering only
+  attr_accessor :inhuman
+  validates :inhuman, inclusion: { :in => [false] }, allow_nil: true
+
   def self.engaged_users
     User.where("confirmed_at IS NOT NULL").select { |u| !u.datasets.blank? }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ActiveRecord::Base
   has_many :received_claims, class_name: 'Claim', foreign_key: 'user_id'
   has_many :certification_campaigns
 
-  attr_accessible :name, :short_name, :email, :password, :password_confirmation, :default_jurisdiction, :organization, :agreed_to_terms, :preferred_locale
+  attr_accessible :name, :short_name, :email, :password, :password_confirmation, :default_jurisdiction, :organization, :agreed_to_terms, :preferred_locale, :inhuman
 
   before_save :ensure_authentication_token
 
@@ -18,7 +18,7 @@ class User < ActiveRecord::Base
 
   # Spam filtering only
   attr_accessor :inhuman
-  validates :inhuman, inclusion: { :in => [false] }, allow_nil: true
+  validates :inhuman, inclusion: { :in => ["0"] }, allow_nil: true
 
   def self.engaged_users
     User.where("confirmed_at IS NOT NULL").select { |u| !u.datasets.blank? }

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -18,4 +18,5 @@
       = f.check_box :agreed_to_terms
       = t('authentication.agree_to_terms', terms_link: link_to(t('authentication.terms'), terms_page_path)).html_safe
 
+  = f.check_box :inhuman, :style => "display: none;", :value => 0
   = f.submit t("authentication.sign_up"), :class => 'btn btn-primary'

--- a/features/agreeing_to_terms.feature
+++ b/features/agreeing_to_terms.feature
@@ -7,7 +7,7 @@ Feature: agreeing to terms of use
   Scenario: I need to agree to the terms of use to save my details
     When I enter an organization of "Example Org"
     And I do not agree to the terms
-    And I enter my password
+    And I enter my current password
     And I click save
     Then there is an error message about agreeing to terms
     And my changes are not saved
@@ -15,7 +15,7 @@ Feature: agreeing to terms of use
   Scenario: I agree to terms of use and save my details
     When I enter an organization of "Example Org"
     And I agree to the terms
-    And I enter my password
+    And I enter my current password
     And I click save
     Then there is no error message
     And my changes are saved

--- a/features/registering_account.feature
+++ b/features/registering_account.feature
@@ -4,10 +4,20 @@ Feature: registering a new account
     Given I visit the home page
     And I click "Register"
 
-  Scenario: I sign up for an account
+  Scenario: I can sign up for an account successfully
     When I enter my email address
     And I enter my password
     And I confirm my password
     And I agree to the terms
     And I click sign up
-    Then my account should be created
+    Then an account should be created
+
+  Scenario: Dumb bots that autotick boxes can't make accounts
+    When I enter my email address
+    And I enter my password
+    And I confirm my password
+    And I agree to the terms
+    And I tick the inhuman box
+    And I click sign up
+    Then an account should not be created
+    And there is an error message about being human

--- a/features/registering_account.feature
+++ b/features/registering_account.feature
@@ -1,0 +1,13 @@
+Feature: registering a new account
+
+  Background:
+    Given I visit the home page
+    And I click "Register"
+
+  Scenario: I sign up for an account
+    When I enter my email address
+    And I enter my password
+    And I confirm my password
+    And I agree to the terms
+    And I click sign up
+    Then my account should be created

--- a/features/step_definitions/user_details.rb
+++ b/features/step_definitions/user_details.rb
@@ -52,6 +52,14 @@ Then(/^there is no error message$/) do
   assert_no_text('Errors occurred')
 end
 
+When(/^I tick the inhuman box$/) do
+  first('#user_inhuman', visible: false).set(true)
+end
+
+Then(/^there is an error message about being human$/) do
+  assert_text('Errors occurred')
+end
+
 Then(/^my changes are saved$/) do
   assert_equal @organization, @user.reload.organization
 end
@@ -60,7 +68,11 @@ Then(/^my changes are not saved$/) do
   refute_equal @organization, @user.reload.organization
 end
 
-Then(/^my account should be created$/) do
-  assert_equal User.count, 1
-  assert_equal User.first.email, @email
+Then(/^an account should be created$/) do
+  assert_equal 1, User.count
+  assert_equal @email, User.first.email
+end
+
+Then(/^an account should not be created$/) do
+  assert_equal 0, User.count
 end

--- a/features/step_definitions/user_details.rb
+++ b/features/step_definitions/user_details.rb
@@ -1,3 +1,7 @@
+Given(/^I visit the home page$/) do
+  visit '/'
+end
+
 Given(/^I visit the edit account page$/) do
   visit edit_user_registration_path(@user)
 end
@@ -15,12 +19,29 @@ When(/^I do not agree to the terms$/) do
   first('#user_agreed_to_terms').set(false)
 end
 
+When(/^I enter my email address$/) do
+  @email = "email@example.com"
+  first('#user_email').set(@email)
+end
+
+When(/^I confirm my password$/) do
+  first('#user_password_confirmation').set('password')
+end
+
 When(/^I enter my password$/) do
+  first('#user_password').set('password')
+end
+
+When(/^I enter my current password$/) do
   first('#user_current_password').set('password')
 end
 
 When(/^I click save$/) do
   click_on 'Update my profile'
+end
+
+When(/^I click sign up$/) do
+  first('#register input[type=submit]').click
 end
 
 Then(/^there is an error message about agreeing to terms$/) do
@@ -37,4 +58,9 @@ end
 
 Then(/^my changes are not saved$/) do
   refute_equal @organization, @user.reload.organization
+end
+
+Then(/^my account should be created$/) do
+  assert_equal User.count, 1
+  assert_equal User.first.email, @email
 end


### PR DESCRIPTION
ODCs suffers from spammy signup requests, by a bot that signs up random email addresses for accounts. This is an attempt to stop it by introducing a checkbox for inhumanity. Bots will *tend to* tick everything in a form (terms, optins, etc) to pass validation, so adding a box that *shouldn't* be ticked is a technique that doesn't hurt users but stops many bots.