### PR TITLE
Setup for delayed_job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,3 +139,4 @@ gem 'sinatra', :require => nil
 gem 'sidekiq-failures'
 gem 'rails-i18n', '~> 3.0.0'
 gem 'eventmachine', '~> 1.2.5'
+gem 'daemons'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       nokogiri (~> 1.5)
       railties (>= 3, < 5.1)
     cucumber-wire (0.0.1)
+    daemons (1.2.6)
     database_cleaner (1.6.2)
     datapackage (0.0.4)
       colorize
@@ -736,6 +737,7 @@ DEPENDENCIES
   coveralls
   csvlint!
   cucumber-rails
+  daemons
   data_kitten!
   database_cleaner
   delayed-plugins-airbrake

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -c 3
+delayed_job: bundle exec rake jobs:work

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,6 @@
+Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+Delayed::Worker.default_log_level = 'debug'.freeze
+Delayed::Worker.max_run_time = 8.hours
+Delayed::Worker.max_attempts = 1
+Delayed::Worker.delay_jobs = false

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,3 +1,5 @@
 Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+Delayed::Worker.default_log_level = 'debug'.freeze
 Delayed::Worker.max_run_time = 8.hours
 Delayed::Worker.max_attempts = 1

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,6 +1,3 @@
 Delayed::Worker.destroy_failed_jobs = false
-Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
-Delayed::Worker.default_log_level = 'debug'.freeze
 Delayed::Worker.max_run_time = 8.hours
 Delayed::Worker.max_attempts = 1
-Delayed::Worker.delay_jobs = false

--- a/lib/tasks/odc.rake
+++ b/lib/tasks/odc.rake
@@ -109,6 +109,7 @@ namespace :odc do
 
   end
 
+  desc "create a csv export from all of the current published datasets"
   task :generate_dataset_csv => :environment do
     Delayed::Job.enqueue CSVExport, { :priority => 5, :run_at => 10.minutes.from_now.utc }
   end


### PR DESCRIPTION
This PR fixes #1693

Changes proposed in this pull request:
Added gem needed to run delayed_job as daemon from script (if needed)
Added back heroku container to run delayed_job to ensure that the rake task: 'odc:generate_dataset_csv' can be picked up.

I have already tested the this rake job with data (and uploaded to rack under another name) to ensure the full csv is uploaded there. While I haven't tested what behaviour occurs yet for downloading a dataset of this size, this changes should at least provide flexibility in allowing delayed_job to run in the background.

I don't have access to the heroku setup/config or the travis setup beyond .travis.yml, but please let me know if there are some circumstances here that don't allow for this change. Otherwise we can look at what else needs to happen to ensure this is scheduled at an appropriate time. For now I can kick off initial the csv export so that we have the latest in rack.
