### PR TITLE
Fix wonky badge display

### DIFF
--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -147,7 +147,7 @@
 
     .span6:last-child p:first-child {
       text-align: center;
-      min-height: 70px;
+      min-height: 90px !important;
     }
 
   }

--- a/app/assets/stylesheets/badge.css.less
+++ b/app/assets/stylesheets/badge.css.less
@@ -15,40 +15,40 @@
     height: 18px;
   }
 
-  // ul.open-data-certificate-details {
-  //   display: none;
-  //   position: absolute;
-  //   left: 85px;
-  //   top: 7px;
-  //   z-index: 5000;
-  //   min-width: 200px;
-  //   text-align: left;
-  //   margin: 0;
-  //   padding: 0;
+  ul.open-data-certificate-details {
+    display: none;
+    position: absolute;
+    left: 85px;
+    top: 7px;
+    z-index: 5000;
+    min-width: 200px;
+    text-align: left;
+    margin: 0;
+    padding: 0;
 
 
-  //   li {
-  //     font-family: 'Helvetica Neue', Helvetica, sans-serif;
-  //     font-size: 12px;
-  //     line-height: 18px;
-  //     height: 18px;
-  //     display: block;
-  //     margin: 0 0 1px 0;
-  //     padding: 0;
-  //     span {
-  //       display: inline-block;
-  //       background-color: black;
-  //       color: white;
-  //       padding: 0 2px;
-  //       max-width: 250px;
-  //       white-space: nowrap;
-  //       overflow: hidden;
-  //       text-overflow: ellipsis;
-  //     }
-  //   }
-  // }
+    li {
+      font-family: 'Helvetica Neue', Helvetica, sans-serif;
+      font-size: 12px;
+      line-height: 18px;
+      height: 18px;
+      display: block;
+      margin: 0 0 1px 0;
+      padding: 0;
+      span {
+        display: inline-block;
+        background-color: black;
+        color: white;
+        padding: 0 2px;
+        max-width: 250px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+  }
 
-  // &:hover ul.open-data-certificate-details {
-  //   display: block;
-  // }
+  &:hover ul.open-data-certificate-details {
+    display: block;
+  }
 }

--- a/app/assets/stylesheets/badge.css.less
+++ b/app/assets/stylesheets/badge.css.less
@@ -1,45 +1,54 @@
 .open-data-certificate {
   position: relative;
+  text-align: center;
 
   img {
     height: 70px;
     width: 77px;
     max-width: 77px;
   }
-
-  ul.open-data-certificate-details {
-    display: none;
-    position: absolute;
-    left: 85px;
-    top: 7px;
-    z-index: 5000;
-    min-width: 200px;
-    text-align: left;
-    margin: 0;
-    padding: 0;
-
-    li {
-      font-family: 'Helvetica Neue', Helvetica, sans-serif;
-      font-size: 12px;
-      line-height: 18px;
-      height: 18px;
-      display: block;
-      margin: 0 0 1px 0;
-      padding: 0;
-      span {
-        display: inline-block;
-        background-color: black;
-        color: white;
-        padding: 0 2px;
-        max-width: 250px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-    }
+  p{
+    font-family: 'Helvetica Neue', Helvetica, sans-serif;
+    text-align: center;
+    font-size: 12px;
+    line-height: 18px;
+    height: 18px;
   }
 
-  &:hover ul.open-data-certificate-details {
-    display: block;
-  }
+  // ul.open-data-certificate-details {
+  //   display: none;
+  //   position: absolute;
+  //   left: 85px;
+  //   top: 7px;
+  //   z-index: 5000;
+  //   min-width: 200px;
+  //   text-align: left;
+  //   margin: 0;
+  //   padding: 0;
+
+
+  //   li {
+  //     font-family: 'Helvetica Neue', Helvetica, sans-serif;
+  //     font-size: 12px;
+  //     line-height: 18px;
+  //     height: 18px;
+  //     display: block;
+  //     margin: 0 0 1px 0;
+  //     padding: 0;
+  //     span {
+  //       display: inline-block;
+  //       background-color: black;
+  //       color: white;
+  //       padding: 0 2px;
+  //       max-width: 250px;
+  //       white-space: nowrap;
+  //       overflow: hidden;
+  //       text-overflow: ellipsis;
+  //     }
+  //   }
+  // }
+
+  // &:hover ul.open-data-certificate-details {
+  //   display: block;
+  // }
 }

--- a/app/views/certificates/_badge.html.haml
+++ b/app/views/certificates/_badge.html.haml
@@ -2,4 +2,4 @@
   %style= "@import url(#{embed_protocol}#{request.host_with_port}/assets/badge.css);"
   = link_to dataset_latest_certificate_url(badge.dataset, protocol: embed_protocol) do
     = image_tag("#{embed_protocol}#{request.host_with_port}#{badge.badge_url}")
-  %p(title= "badge.response_set.title #{t("levels.#{badge.attained_level || 'none'}.title")}  #{t("#{badge.certification_type}", scope: 'certificate.certification_types')}") #{t("levels.#{badge.attained_level || 'none'}.title")}
+  %p(title= "#{badge.response_set.title} - ODI #{t("levels.#{badge.attained_level || 'none'}.title")} Certificate - #{t("#{badge.certification_type}", scope: 'certificate.certification_types')} - #{badge.expired? ? 'Expired' : 'Active'}") #{t("levels.#{badge.attained_level || 'none'}.title")}

--- a/app/views/certificates/_badge.html.haml
+++ b/app/views/certificates/_badge.html.haml
@@ -2,10 +2,4 @@
   %style= "@import url(#{embed_protocol}#{request.host_with_port}/assets/badge.css);"
   = link_to dataset_latest_certificate_url(badge.dataset, protocol: embed_protocol) do
     = image_tag("#{embed_protocol}#{request.host_with_port}#{badge.badge_url}")
-  %ul.open-data-certificate-details
-    %li
-      %span= badge.response_set.title
-    %li
-      %span= "#{t("levels.#{badge.attained_level || 'none'}.title")} Open Data Certificate (#{badge.response_set.survey.try(:status)})"
-    %li
-      %span= "#{badge.expired? ? 'Expired' : 'Active'} - #{t("#{badge.certification_type}", scope: 'certificate.certification_types')}"
+  %p = "#{t("levels.#{badge.attained_level || 'none'}.title")}  #{t("#{badge.certification_type}", scope: 'certificate.certification_types')}"

--- a/app/views/certificates/_badge.html.haml
+++ b/app/views/certificates/_badge.html.haml
@@ -2,4 +2,4 @@
   %style= "@import url(#{embed_protocol}#{request.host_with_port}/assets/badge.css);"
   = link_to dataset_latest_certificate_url(badge.dataset, protocol: embed_protocol) do
     = image_tag("#{embed_protocol}#{request.host_with_port}#{badge.badge_url}")
-  %p = "#{t("levels.#{badge.attained_level || 'none'}.title")}  #{t("#{badge.certification_type}", scope: 'certificate.certification_types')}"
+  %p(title= "badge.response_set.title #{t("levels.#{badge.attained_level || 'none'}.title")}  #{t("#{badge.certification_type}", scope: 'certificate.certification_types')}") #{t("levels.#{badge.attained_level || 'none'}.title")}

--- a/app/views/certificates/_badge.html.haml
+++ b/app/views/certificates/_badge.html.haml
@@ -1,5 +1,5 @@
-.open-data-certificate
+.open-data-certificate(title= "#{badge.response_set.title} - ODI #{t("levels.#{badge.attained_level || 'none'}.title")} Certificate - #{t("#{badge.certification_type}", scope: 'certificate.certification_types')} - #{badge.expired? ? 'Expired' : 'Active'}")  
   %style= "@import url(#{embed_protocol}#{request.host_with_port}/assets/badge.css);"
   = link_to dataset_latest_certificate_url(badge.dataset, protocol: embed_protocol) do
     = image_tag("#{embed_protocol}#{request.host_with_port}#{badge.badge_url}")
-  %p(title= "#{badge.response_set.title} - ODI #{t("levels.#{badge.attained_level || 'none'}.title")} Certificate - #{t("#{badge.certification_type}", scope: 'certificate.certification_types')} - #{badge.expired? ? 'Expired' : 'Active'}") #{t("levels.#{badge.attained_level || 'none'}.title")}
+  %p #{t("levels.#{badge.attained_level || 'none'}.title")}


### PR DESCRIPTION
A recent merge from staging appears to have deployed an old experiment of swapping HTML-snippet badges to js-based badges. However, the display of text about the certificate on hover was not the most aesthetic:

![Screenshot 2019-05-21 17 33 08](https://user-images.githubusercontent.com/604646/58113906-837dbf80-7bee-11e9-8966-c74f46444ede.png)

This PR fixes this style, making the JS-generated badge very similar to the old one, with a lot of extra info about certificate type and status on hover via title attribute.

![Screenshot 2019-05-21 17 36 05](https://user-images.githubusercontent.com/604646/58114098-f2f3af00-7bee-11e9-9cc2-c44d6a04e9cb.png)
